### PR TITLE
Fix check endpoint

### DIFF
--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -4,7 +4,7 @@ namespace SandwaveIo\RealtimeRegister\Api;
 
 use SandwaveIo\RealtimeRegister\Domain\BillableCollection;
 use SandwaveIo\RealtimeRegister\Domain\ContactCollection;
-use SandwaveIo\RealtimeRegister\Domain\DomainAvailabilityCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainAvailability;
 use SandwaveIo\RealtimeRegister\Domain\DomainDetails;
 use SandwaveIo\RealtimeRegister\Domain\DomainDetailsCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainRegistration;
@@ -58,9 +58,9 @@ final class DomainsApi extends AbstractApi
      * @param string      $domainName
      * @param string|null $languageCode
      *
-     * @return DomainAvailabilityCollection
+     * @return DomainAvailability
      */
-    public function check(string $domainName, ?string $languageCode = null): DomainAvailabilityCollection
+    public function check(string $domainName, ?string $languageCode = null): DomainAvailability
     {
         $query = [];
         if (! is_null($languageCode)) {
@@ -68,7 +68,7 @@ final class DomainsApi extends AbstractApi
         }
 
         $response = $this->client->get("v2/domains/{$domainName}/check", $query);
-        return DomainAvailabilityCollection::fromArray($response->json());
+        return DomainAvailability::fromArray($response->json());
     }
 
     public function register(

--- a/tests/Clients/DomainsApiCheckTest.php
+++ b/tests/Clients/DomainsApiCheckTest.php
@@ -3,7 +3,7 @@
 namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 
 use PHPUnit\Framework\TestCase;
-use SandwaveIo\RealtimeRegister\Domain\DomainAvailabilityCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainAvailability;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class DomainsApiCheckTest extends TestCase
@@ -12,45 +12,23 @@ class DomainsApiCheckTest extends TestCase
     {
         $sdk = MockedClientFactory::makeSdk(
             200,
-            json_encode([
-                'entities' => [
-                    include __DIR__ . '/../Domain/data/domain_availability_valid.php',
-                    include __DIR__ . '/../Domain/data/domain_availability_valid.php',
-                    include __DIR__ . '/../Domain/data/domain_availability_valid.php',
-                ],
-                'pagination' => [
-                    'total'  => 3,
-                    'offset' => 0,
-                    'limit'  => 10,
-                ],
-            ]),
+            json_encode(include __DIR__ . '/../Domain/data/domain_availability_valid.php'),
             MockedClientFactory::assertRoute('GET', 'v2/domains/example.com/check', $this)
         );
 
         $response = $sdk->domains->check('example.com');
-        $this->assertInstanceOf(DomainAvailabilityCollection::class, $response);
+        $this->assertInstanceOf(DomainAvailability::class, $response);
     }
 
     public function test_check_with_languageCode(): void
     {
         $sdk = MockedClientFactory::makeSdk(
             200,
-            json_encode([
-                'entities' => [
-                    include __DIR__ . '/../Domain/data/domain_availability_valid.php',
-                    include __DIR__ . '/../Domain/data/domain_availability_valid.php',
-                    include __DIR__ . '/../Domain/data/domain_availability_valid.php',
-                ],
-                'pagination' => [
-                    'total'  => 3,
-                    'offset' => 0,
-                    'limit'  => 10,
-                ],
-            ]),
+            json_encode(include __DIR__ . '/../Domain/data/domain_availability_valid.php'),
             MockedClientFactory::assertRoute('GET', 'v2/domains/example.com/check', $this)
         );
 
         $response = $sdk->domains->check('example.com', 'nl');
-        $this->assertInstanceOf(DomainAvailabilityCollection::class, $response);
+        $this->assertInstanceOf(DomainAvailability::class, $response);
     }
 }


### PR DESCRIPTION
The current check endpoint is broken, it does not return a collection even though the code was built around that ([see docs](https://dm.realtimeregister.com/docs/api/domains/check)).

I have fixed it and updated the tests.