### PR TITLE
Add providers API

### DIFF
--- a/src/Api/ContactsApi.php
+++ b/src/Api/ContactsApi.php
@@ -30,7 +30,7 @@ final class ContactsApi extends AbstractApi
             $query['offset'] = $offset;
         }
         if (! is_null($search)) {
-            $query['search'] = $search;
+            $query['q'] = $search;
         }
 
         $response = $this->client->get("v2/customers/{$customer}/contacts", $query);
@@ -308,7 +308,7 @@ final class ContactsApi extends AbstractApi
             $query['offset'] = $offset;
         }
         if (! is_null($search)) {
-            $query['search'] = $search;
+            $query['q'] = $search;
         }
 
         $response = $this->client->get('v2/countries', $query);

--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -49,7 +49,7 @@ final class DomainsApi extends AbstractApi
             $query['offset'] = $offset;
         }
         if (! is_null($search)) {
-            $query['search'] = $search;
+            $query['q'] = $search;
         }
 
         $response = $this->client->get('v2/domains', $query);

--- a/src/Api/NotificationsApi.php
+++ b/src/Api/NotificationsApi.php
@@ -43,7 +43,7 @@ final class NotificationsApi extends AbstractApi
             $query['offset'] = $offset;
         }
         if (! is_null($search)) {
-            $query['search'] = $search;
+            $query['q'] = $search;
         }
 
         $response = $this->client->get("v2/customers/{$customer}/notifications", $query);

--- a/src/Api/ProvidersApi.php
+++ b/src/Api/ProvidersApi.php
@@ -40,7 +40,7 @@ final class ProvidersApi extends AbstractApi
             $query['offset'] = $offset;
         }
         if (! is_null($search)) {
-            $query['search'] = $search;
+            $query['q'] = $search;
         }
 
         $response = $this->client->get('v2/providers', $query);

--- a/src/Api/ProvidersApi.php
+++ b/src/Api/ProvidersApi.php
@@ -81,7 +81,7 @@ final class ProvidersApi extends AbstractApi
             $query['offset'] = $offset;
         }
         if (! is_null($search)) {
-            $query['search'] = $search;
+            $query['q'] = $search;
         }
 
         $response = $this->client->get('v2/providers/downtime', $query);

--- a/src/Api/ProvidersApi.php
+++ b/src/Api/ProvidersApi.php
@@ -1,0 +1,90 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Api;
+
+use SandwaveIo\RealtimeRegister\Domain\Downtime;
+use SandwaveIo\RealtimeRegister\Domain\DowntimeCollection;
+use SandwaveIo\RealtimeRegister\Domain\Provider;
+use SandwaveIo\RealtimeRegister\Domain\ProviderCollection;
+
+final class ProvidersApi extends AbstractApi
+{
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/providers/get
+     *
+     * @param string $name
+     *
+     * @return Provider
+     */
+    public function get(string $name): Provider
+    {
+        $response = $this->client->get("/v2/providers/REGISTRY/{$name}");
+        return Provider::fromArray($response->json());
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/providers/list
+     *
+     * @return ProviderCollection
+     */
+    public function list(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $search = null
+    ): ProviderCollection {
+        $query = [];
+        if (! is_null($limit)) {
+            $query['limit'] = $limit;
+        }
+        if (! is_null($offset)) {
+            $query['offset'] = $offset;
+        }
+        if (! is_null($search)) {
+            $query['search'] = $search;
+        }
+
+        $response = $this->client->get('v2/providers', $query);
+        return ProviderCollection::fromArray($response->json());
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/providers/downtime/get
+     *
+     * @param int $id
+     *
+     * @return Downtime
+     */
+    public function getDowntime(int $id): Downtime
+    {
+        return Downtime::fromArray($this->client->get("/v2/providers/downtime/{$id}")->json());
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/providers/downtime/list
+     *
+     * @param int|null    $limit
+     * @param int|null    $offset
+     * @param string|null $search
+     *
+     * @return DowntimeCollection
+     */
+    public function listDowntimes(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $search = null
+    ): DowntimeCollection {
+        $query = [];
+        if (! is_null($limit)) {
+            $query['limit'] = $limit;
+        }
+        if (! is_null($offset)) {
+            $query['offset'] = $offset;
+        }
+        if (! is_null($search)) {
+            $query['search'] = $search;
+        }
+
+        $response = $this->client->get('v2/providers/downtime', $query);
+        return DowntimeCollection::fromArray($response->json());
+    }
+}

--- a/src/Domain/Downtime.php
+++ b/src/Domain/Downtime.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+use Carbon\Carbon;
+
+final class Downtime implements DomainObjectInterface
+{
+    /** @var int */
+    public $id;
+
+    /** @var Carbon */
+    public $startDate;
+
+    /** @var Carbon */
+    public $endDate;
+
+    /** @var string|null */
+    public $reason;
+
+    /** @var Provider */
+    public $provider;
+
+    private function __construct(
+        Carbon $startDate,
+        Carbon $endDate,
+        ?string $reason,
+        Provider $provider
+    ) {
+        $this->startDate = $startDate;
+        $this->endDate = $endDate;
+        $this->reason = $reason;
+        $this->provider = $provider;
+    }
+
+    public static function fromArray(array $json): Downtime
+    {
+        return new Downtime(
+            new Carbon($json['startDate']),
+            new Carbon($json['endDate']),
+            $json['reason'],
+            Provider::fromArray($json['provider'])
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'id' => $this->id,
+            'startDate' => $this->startDate->toDateTimeString(),
+            'endDate' => $this->endDate->toDateTimeString(),
+            'reason' => $this->reason,
+            'provider' => $this->provider->toArray(),
+        ], function ($x) {
+            return ! is_null($x);
+        });
+    }
+}

--- a/src/Domain/Downtime.php
+++ b/src/Domain/Downtime.php
@@ -3,6 +3,7 @@
 namespace SandwaveIo\RealtimeRegister\Domain;
 
 use Carbon\Carbon;
+use TypeError;
 
 final class Downtime implements DomainObjectInterface
 {
@@ -22,11 +23,13 @@ final class Downtime implements DomainObjectInterface
     public $provider;
 
     private function __construct(
+        int $id,
         Carbon $startDate,
         Carbon $endDate,
         ?string $reason,
         Provider $provider
     ) {
+        $this->id = $id;
         $this->startDate = $startDate;
         $this->endDate = $endDate;
         $this->reason = $reason;
@@ -35,10 +38,22 @@ final class Downtime implements DomainObjectInterface
 
     public static function fromArray(array $json): Downtime
     {
+        try {
+            $startDate = new Carbon($json['startDate']);
+        } catch (\Throwable $th) {
+            throw new TypeError('Invalid start date received');
+        }
+        try {
+            $endDate = new Carbon($json['endDate']);
+        } catch (\Throwable $th) {
+            throw new TypeError('Invalid end date received');
+        }
+
         return new Downtime(
-            new Carbon($json['startDate']),
-            new Carbon($json['endDate']),
-            $json['reason'],
+            $json['id'],
+            $startDate,
+            $endDate,
+            $json['reason'] ?? null,
             Provider::fromArray($json['provider'])
         );
     }

--- a/src/Domain/DowntimeCollection.php
+++ b/src/Domain/DowntimeCollection.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class DowntimeCollection extends AbstractCollection
+{
+    /** @var Downtime[] */
+    public $entities;
+
+    public static function fromArray(array $json): DowntimeCollection
+    {
+        return parent::fromArray($json);
+    }
+
+    public function offsetGet($offset): ?Downtime
+    {
+        return isset($this->entities[$offset]) ? $this->entities[$offset] : null;
+    }
+
+    public static function parseChild(array $json): Downtime
+    {
+        return Downtime::fromArray($json);
+    }
+}

--- a/src/Domain/Provider.php
+++ b/src/Domain/Provider.php
@@ -22,7 +22,7 @@ final class Provider implements DomainObjectInterface
     {
         return new Provider(
             $json['name'],
-            $json['tlds'] ?? []
+            $json['tlds'] ?? null
         );
     }
 

--- a/src/Domain/Provider.php
+++ b/src/Domain/Provider.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class Provider implements DomainObjectInterface
+{
+    /** @var string */
+    public $name;
+
+    /** @var string[]|null */
+    public $tlds;
+
+    private function __construct(
+        string $name,
+        ?array $tlds
+    ) {
+        $this->name = $name;
+        $this->tlds = $tlds;
+    }
+
+    public static function fromArray(array $json): Provider
+    {
+        return new Provider(
+            $json['name'],
+            $json['tlds'] ?? []
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'tlds' => $this->tlds,
+        ], function ($x) {
+            return ! is_null($x);
+        });
+    }
+}

--- a/src/Domain/ProviderCollection.php
+++ b/src/Domain/ProviderCollection.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class ProviderCollection extends AbstractCollection
+{
+    /** @var Provider[] */
+    public $entities;
+
+    public static function fromArray(array $json): ProviderCollection
+    {
+        return parent::fromArray($json);
+    }
+
+    public function offsetGet($offset): ?Provider
+    {
+        return isset($this->entities[$offset]) ? $this->entities[$offset] : null;
+    }
+
+    public static function parseChild(array $json): Provider
+    {
+        return Provider::fromArray($json);
+    }
+}

--- a/src/RealtimeRegister.php
+++ b/src/RealtimeRegister.php
@@ -7,6 +7,7 @@ use SandwaveIo\RealtimeRegister\Api\ContactsApi;
 use SandwaveIo\RealtimeRegister\Api\CustomersApi;
 use SandwaveIo\RealtimeRegister\Api\DomainsApi;
 use SandwaveIo\RealtimeRegister\Api\NotificationsApi;
+use SandwaveIo\RealtimeRegister\Api\ProvidersApi;
 use SandwaveIo\RealtimeRegister\Api\TLDsApi;
 use SandwaveIo\RealtimeRegister\Support\AuthorizedClient;
 
@@ -29,6 +30,9 @@ final class RealtimeRegister
     /** @var NotificationsApi */
     public $notifications;
 
+    /** @var ProvidersApi */
+    public $providers;
+
     public function __construct(string $apiKey, ?string $baseUrl = null, ?LoggerInterface $logger = null)
     {
         $url = $baseUrl ?: RealtimeRegister::BASE_URL;
@@ -42,5 +46,6 @@ final class RealtimeRegister
         $this->domains   = new DomainsApi($client);
         $this->tlds      = new TLDsApi($client);
         $this->notifications  = new NotificationsApi($client);
+        $this->providers = new ProvidersApi($client);
     }
 }

--- a/tests/Clients/ProvidersApiGetDowntimeTest.php
+++ b/tests/Clients/ProvidersApiGetDowntimeTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\Downtime;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class ProvidersApiGetDowntimeTest extends TestCase
+{
+    public function test_get_downtime(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/downtime_valid.php'),
+            MockedClientFactory::assertRoute('GET', '/v2/providers/downtime/1', $this)
+        );
+
+        $response = $sdk->providers->getDowntime(1);
+        $this->assertInstanceOf(Downtime::class, $response);
+    }
+}

--- a/tests/Clients/ProvidersApiGetTest.php
+++ b/tests/Clients/ProvidersApiGetTest.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\Provider;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class ProvidersApiGetTest extends TestCase
+{
+    public function test_get(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/provider_valid.php'),
+            MockedClientFactory::assertRoute('GET', '/v2/providers/REGISTRY/providername', $this)
+        );
+
+        $response = $sdk->providers->get('providername');
+        $this->assertInstanceOf(Provider::class, $response);
+    }
+}

--- a/tests/Clients/ProvidersApiListDowntimesTest.php
+++ b/tests/Clients/ProvidersApiListDowntimesTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\DowntimeCollection;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class ProvidersApiListDowntimesTest extends TestCase
+{
+    public function test_list_downtimes(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/providers/downtime', $this)
+        );
+
+        $response = $sdk->providers->listDowntimes();
+        $this->assertInstanceOf(DowntimeCollection::class, $response);
+    }
+
+    public function test_list_downtimes_with_queries(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/providers/downtime', $this)
+        );
+
+        $response = $sdk->providers->listDowntimes(10, 0, '');
+        $this->assertInstanceOf(DowntimeCollection::class, $response);
+    }
+}

--- a/tests/Clients/ProvidersApiListTest.php
+++ b/tests/Clients/ProvidersApiListTest.php
@@ -1,0 +1,56 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\ProviderCollection;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class ProvidersApiListTest extends TestCase
+{
+    public function test_list(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/providers', $this)
+        );
+
+        $response = $sdk->providers->list();
+        $this->assertInstanceOf(ProviderCollection::class, $response);
+    }
+
+    public function test_list_with_queries(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/providers', $this)
+        );
+
+        $response = $sdk->providers->list(3, 0, 'providername');
+        $this->assertInstanceOf(ProviderCollection::class, $response);
+    }
+}

--- a/tests/Domain/DomainCollectionTest.php
+++ b/tests/Domain/DomainCollectionTest.php
@@ -12,12 +12,14 @@ use SandwaveIo\RealtimeRegister\Domain\DomainAvailabilityCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainContactCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainDetailsCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainObjectInterface;
+use SandwaveIo\RealtimeRegister\Domain\DowntimeCollection;
 use SandwaveIo\RealtimeRegister\Domain\DsDataCollection;
 use SandwaveIo\RealtimeRegister\Domain\KeyDataCollection;
 use SandwaveIo\RealtimeRegister\Domain\LaunchPhaseCollection;
 use SandwaveIo\RealtimeRegister\Domain\LogCollection;
 use SandwaveIo\RealtimeRegister\Domain\NotificationCollection;
 use SandwaveIo\RealtimeRegister\Domain\PriceCollection;
+use SandwaveIo\RealtimeRegister\Domain\ProviderCollection;
 
 /**
  * This TestCase is used to test all Domain Object Collections.
@@ -48,6 +50,8 @@ class DomainCollectionTest extends TestCase
             'launch phase collection' => [LaunchPhaseCollection::class, include __DIR__ . '/data/launch_phase.php'],
             'log collection' => [LogCollection::class, include __DIR__ . '/data/log.php'],
             'notification collection' => [NotificationCollection::class, include __DIR__ . '/data/notification_valid.php'],
+            'provider collection' => [ProviderCollection::class, include __DIR__ . '/data/provider_valid.php'],
+            'downtime collection' => [DowntimeCollection::class, include __DIR__ . '/data/downtime_valid.php'],
         ];
         // For each type, create a flat and a pagination scenario.
         $dataset = [];

--- a/tests/Domain/DomainObjectTest.php
+++ b/tests/Domain/DomainObjectTest.php
@@ -249,13 +249,46 @@ class DomainObjectTest extends TestCase
                 include __DIR__ . '/data/notification_poll_invalid_count.php',
                 TypeError::class,
             ],
-            'valid provider' => [
+            'valid provider (all fields)' => [
                 Provider::class,
                 include __DIR__ . '/data/provider_valid.php',
             ],
-            'valid downtime' => [
+            'valid provider (only required)' => [
+                Provider::class,
+                include __DIR__ . '/data/provider_valid_only_required.php',
+            ],
+            'invalid provider (name)' => [
+                Provider::class,
+                include __DIR__ . '/data/provider_invalid_name.php',
+                TypeError::class,
+            ],
+            'valid downtime (all fields)' => [
                 Downtime::class,
                 include __DIR__ . '/data/downtime_valid.php',
+            ],
+            'valid downtime (only required)' => [
+                Downtime::class,
+                include __DIR__ . '/data/downtime_valid_only_required.php',
+            ],
+            'invalid downtime (id)' => [
+                Downtime::class,
+                include __DIR__ . '/data/downtime_invalid_id.php',
+                TypeError::class,
+            ],
+            'invalid downtime (start date)' => [
+                Downtime::class,
+                include __DIR__ . '/data/downtime_invalid_start_date.php',
+                TypeError::class,
+            ],
+            'invalid downtime (end date)' => [
+                Downtime::class,
+                include __DIR__ . '/data/downtime_invalid_end_date.php',
+                TypeError::class,
+            ],
+            'invalid downtime (provider)' => [
+                Downtime::class,
+                include __DIR__ . '/data/downtime_invalid_provider.php',
+                TypeError::class,
             ],
         ];
     }

--- a/tests/Domain/DomainObjectTest.php
+++ b/tests/Domain/DomainObjectTest.php
@@ -16,6 +16,7 @@ use SandwaveIo\RealtimeRegister\Domain\DomainDetails;
 use SandwaveIo\RealtimeRegister\Domain\DomainRegistration;
 use SandwaveIo\RealtimeRegister\Domain\DomainSyntax;
 use SandwaveIo\RealtimeRegister\Domain\DomainTransferStatus;
+use SandwaveIo\RealtimeRegister\Domain\Downtime;
 use SandwaveIo\RealtimeRegister\Domain\DsData;
 use SandwaveIo\RealtimeRegister\Domain\KeyData;
 use SandwaveIo\RealtimeRegister\Domain\LaunchPhase;
@@ -24,6 +25,7 @@ use SandwaveIo\RealtimeRegister\Domain\Nameservers;
 use SandwaveIo\RealtimeRegister\Domain\Notification;
 use SandwaveIo\RealtimeRegister\Domain\NotificationPoll;
 use SandwaveIo\RealtimeRegister\Domain\Price;
+use SandwaveIo\RealtimeRegister\Domain\Provider;
 use SandwaveIo\RealtimeRegister\Domain\Registrant;
 use SandwaveIo\RealtimeRegister\Domain\TLDInfo;
 use SandwaveIo\RealtimeRegister\Domain\Zone;
@@ -246,6 +248,14 @@ class DomainObjectTest extends TestCase
                 NotificationPoll::class,
                 include __DIR__ . '/data/notification_poll_invalid_count.php',
                 TypeError::class,
+            ],
+            'valid provider' => [
+                Provider::class,
+                include __DIR__ . '/data/provider_valid.php',
+            ],
+            'valid downtime' => [
+                Downtime::class,
+                include __DIR__ . '/data/downtime_valid.php',
             ],
         ];
     }

--- a/tests/Domain/data/downtime_invalid_end_date.php
+++ b/tests/Domain/data/downtime_invalid_end_date.php
@@ -3,7 +3,7 @@
 return [
     'id' => 1,
     'startDate' => '2020-03-04 15:00:00',
-    'endDate' => '2021-03-04 17:00:00',
+    'endDate' => 'Invalid Date',
     'reason' => 'Reason Test One',
     'provider' => include __DIR__ . '/provider_valid.php',
 ];

--- a/tests/Domain/data/downtime_invalid_id.php
+++ b/tests/Domain/data/downtime_invalid_id.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types = 1);
 
 return [
-    'id' => 1,
+    'id' => 'one',
     'startDate' => '2020-03-04 15:00:00',
     'endDate' => '2021-03-04 17:00:00',
     'reason' => 'Reason Test One',

--- a/tests/Domain/data/downtime_invalid_provider.php
+++ b/tests/Domain/data/downtime_invalid_provider.php
@@ -5,5 +5,5 @@ return [
     'startDate' => '2020-03-04 15:00:00',
     'endDate' => '2021-03-04 17:00:00',
     'reason' => 'Reason Test One',
-    'provider' => include __DIR__ . '/provider_valid.php',
+    'provider' => include __DIR__ . '/provider_invalid_name.php',
 ];

--- a/tests/Domain/data/downtime_invalid_start_date.php
+++ b/tests/Domain/data/downtime_invalid_start_date.php
@@ -2,8 +2,8 @@
 
 return [
     'id' => 1,
-    'startDate' => '2020-03-04 15:00:00',
-    'endDate' => '2021-03-04 17:00:00',
+    'startDate' => 'Invalid Date',
+    'endDate' => '2020-03-04 17:00:00',
     'reason' => 'Reason Test One',
     'provider' => include __DIR__ . '/provider_valid.php',
 ];

--- a/tests/Domain/data/downtime_valid.php
+++ b/tests/Domain/data/downtime_valid.php
@@ -1,0 +1,8 @@
+<?php declare(strict_types = 1);
+
+return [
+    'startDate' => '2020-03-04 12:34:56',
+    'endDate' => '2021-03-04 12:34:56',
+    'reason' => 'Reason Test One',
+    'provider' => include __DIR__ . '/provider_valid.php',
+];

--- a/tests/Domain/data/downtime_valid_only_required.php
+++ b/tests/Domain/data/downtime_valid_only_required.php
@@ -4,6 +4,5 @@ return [
     'id' => 1,
     'startDate' => '2020-03-04 15:00:00',
     'endDate' => '2021-03-04 17:00:00',
-    'reason' => 'Reason Test One',
     'provider' => include __DIR__ . '/provider_valid.php',
 ];

--- a/tests/Domain/data/provider_invalid_name.php
+++ b/tests/Domain/data/provider_invalid_name.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
 return [
-    'name' => 'Provider Name Test',
+    'name' => 123,
     'tlds' => ['com', 'net'],
 ];

--- a/tests/Domain/data/provider_valid.php
+++ b/tests/Domain/data/provider_valid.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types = 1);
+
+return [
+    'name' => 'Provider Name Test',
+    'tlds' => ['.com', '.net'],
+];

--- a/tests/Domain/data/provider_valid_only_required.php
+++ b/tests/Domain/data/provider_valid_only_required.php
@@ -2,5 +2,4 @@
 
 return [
     'name' => 'Provider Name Test',
-    'tlds' => ['com', 'net'],
 ];

--- a/tests/RealtimeRegisterClientTest.php
+++ b/tests/RealtimeRegisterClientTest.php
@@ -7,6 +7,7 @@ use SandwaveIo\RealtimeRegister\Api\ContactsApi;
 use SandwaveIo\RealtimeRegister\Api\CustomersApi;
 use SandwaveIo\RealtimeRegister\Api\DomainsApi;
 use SandwaveIo\RealtimeRegister\Api\NotificationsApi;
+use SandwaveIo\RealtimeRegister\Api\ProvidersApi;
 use SandwaveIo\RealtimeRegister\RealtimeRegister;
 use SandwaveIo\RealtimeRegister\Support\AuthorizedClient;
 
@@ -24,5 +25,6 @@ class RealtimeRegisterClientTest extends TestCase
         $this->assertInstanceOf(CustomersApi::class, $client->customers, 'The customers could not be instantiated.');
         $this->assertInstanceOf(DomainsApi::class, $client->domains, 'The domains could not be instantiated.');
         $this->assertInstanceOf(NotificationsApi::class, $client->notifications, 'The notifications could not be instantiated.');
+        $this->assertInstanceOf(ProvidersApi::class, $client->providers, 'The providers could not be instantiated.');
     }
 }


### PR DESCRIPTION
@FrontEndCoffee Hey! I am creating this PR with the requested changes in https://github.com/sandwave-io/realtimeregister-php/issues/9, but I have a question that maybe makes the PR incomplete. 

When we do filter on lists, for every domain object, the code is using a general approach of sending a param named `$search`. 
I did the same for `Providers` and `Downtimes`, but I saw that `search` is not a valid filter, and we have a list of valid params for every listing. Example: https://dm.realtimeregister.com/docs/api/providers/downtime/list

I thought in adding these filters, but it is not convenient to pass so many parameters to a method. Maybe you have planned another approach for this (or maybe I am missunderstanding something :) )

I hope the question has sense. I wait for yout comments, and thanks for letting me work on this issue!