### PR TITLE
Use array for domain status as described in documentation

### DIFF
--- a/src/Domain/DomainDetails.php
+++ b/src/Domain/DomainDetails.php
@@ -4,6 +4,7 @@ namespace SandwaveIo\RealtimeRegister\Domain;
 
 use DateTime;
 use SandwaveIo\RealtimeRegister\Domain\Enum\DomainStatusEnum;
+use Webmozart\Assert\Assert;
 
 final class DomainDetails implements DomainObjectInterface
 {
@@ -22,7 +23,7 @@ final class DomainDetails implements DomainObjectInterface
     /** @var bool */
     public $privacyProtect;
 
-    /** @var string */
+    /** @var string[] */
     public $status;
 
     /** @var string|null */
@@ -73,7 +74,7 @@ final class DomainDetails implements DomainObjectInterface
         string $customer,
         string $registrant,
         bool $privacyProtect,
-        string $status,
+        array $status,
         ?string $authcode,
         ?string $languageCode,
         bool $autoRenew,
@@ -113,7 +114,11 @@ final class DomainDetails implements DomainObjectInterface
 
     public static function fromArray(array $json): DomainDetails
     {
-        DomainStatusEnum::validate($json['status']);
+        Assert::isArray($json['status']);
+
+        foreach ($json['status'] as $status) {
+            DomainStatusEnum::validate($status);
+        }
 
         return new DomainDetails(
             $json['domainName'],

--- a/tests/Domain/data/domain_details_invalid.php
+++ b/tests/Domain/data/domain_details_invalid.php
@@ -6,7 +6,7 @@ return [
     'customer' => 'johndoe',
     'registrant' => 'johndoe',
     'privacyProtect' => false,
-    'status' => 'PENDING_RENEWasdfasdfasdf',
+    'status' => ['PENDING_RENEWasdfasdfasdf'],
     'authcode' => '294759302',
     'languageCode' => 'nl',
     'autoRenew' => true,

--- a/tests/Domain/data/domain_details_valid.php
+++ b/tests/Domain/data/domain_details_valid.php
@@ -6,7 +6,7 @@ return [
     'customer' => 'johndoe',
     'registrant' => 'johndoe',
     'privacyProtect' => false,
-    'status' => 'PENDING_RENEW',
+    'status' => ['PENDING_RENEW'],
     'authcode' => '294759302',
     'languageCode' => 'nl',
     'autoRenew' => true,

--- a/tests/Domain/data/domain_details_valid_only_required.php
+++ b/tests/Domain/data/domain_details_valid_only_required.php
@@ -6,7 +6,7 @@ return [
     'customer' => 'johndoe',
     'registrant' => 'johndoe',
     'privacyProtect' => false,
-    'status' => 'PENDING_RENEW',
+    'status' => ['PENDING_RENEW'],
     'authcode' => '294759302',
     'languageCode' => 'nl',
     'autoRenew' => true,


### PR DESCRIPTION
According to the documentation the status of a name is an array of statuses.
https://dm.realtimeregister.com/docs/api/domains/get#response