### PR TITLE
Use better version constraint webmozart/assert 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.2.0|^7.0.1",
         "psr/log": "^1.1",
-        "webmozart/assert": "~1.3.0"
+        "webmozart/assert": "^1.3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",


### PR DESCRIPTION
Could not install the package on a fresh Laravel 8 install.
This is becuase laravel requires dragonmantank/cron-expression which in turn requires webmozart/assert version 1.7.0