### PR TITLE
DNSSEC key data should be returned as is

### DIFF
--- a/src/Domain/KeyData.php
+++ b/src/Domain/KeyData.php
@@ -38,7 +38,7 @@ final class KeyData implements DomainObjectInterface
             $json['protocol'],
             $json['flags'],
             $json['algorithm'],
-            $decodedKey
+            $json['publicKey']
         );
     }
 
@@ -48,7 +48,7 @@ final class KeyData implements DomainObjectInterface
             'protocol' => $this->protocol,
             'flags' => $this->flags,
             'algorithm' => $this->algorithm,
-            'publicKey' => base64_encode($this->publicKey),
+            'publicKey' => $this->publicKey,
         ];
     }
 }

--- a/tests/Clients/DomainsApiGetTest.php
+++ b/tests/Clients/DomainsApiGetTest.php
@@ -10,13 +10,16 @@ class DomainsApiGetTest extends TestCase
 {
     public function test_get(): void
     {
+        $validDomainDetails = include __DIR__ . '/../Domain/data/domain_details_valid.php';
         $sdk = MockedClientFactory::makeSdk(
             200,
-            json_encode(include __DIR__ . '/../Domain/data/domain_details_valid.php'),
+            json_encode($validDomainDetails),
             MockedClientFactory::assertRoute('GET', 'v2/domains/example.com', $this)
         );
 
         $response = $sdk->domains->get('example.com');
+
         $this->assertInstanceOf(DomainDetails::class, $response);
+        $this->assertSame($validDomainDetails, $response->toArray());
     }
 }

--- a/tests/Domain/data/key_data_invalid.php
+++ b/tests/Domain/data/key_data_invalid.php
@@ -4,5 +4,5 @@ return [
     'protocol' => 3,
     'flags' => 256,
     'algorithm' => 100001,
-    'publicKey' => 'LS0tUlNBLS0tIGFzZGZhc2RmYXNkZmFzZGZhc2Rm',
+    'publicKey' => 'TFMwdFVsTkJMUzB0SUdGelpHWmhjMlJtWVhOa1ptRnpaR1poYzJSbQ==',
 ];

--- a/tests/Domain/data/key_data_invalid_flag.php
+++ b/tests/Domain/data/key_data_invalid_flag.php
@@ -4,5 +4,5 @@ return [
     'protocol' => 3,
     'flags' => 2533336,
     'algorithm' => 100001,
-    'publicKey' => 'LS0tUlNBLS0tIGFzZGZhc2RmYXNkZmFzZGZhc2Rm',
+    'publicKey' => 'TFMwdFVsTkJMUzB0SUdGelpHWmhjMlJtWVhOa1ptRnpaR1poYzJSbQ==',
 ];

--- a/tests/Domain/data/key_data_invalid_protocol.php
+++ b/tests/Domain/data/key_data_invalid_protocol.php
@@ -4,5 +4,5 @@ return [
     'protocol' => 333,
     'flags' => 256,
     'algorithm' => 10,
-    'publicKey' => 'LS0tUlNBLS0tIGFzZGZhc2RmYXNkZmFzZGZhc2Rm',
+    'publicKey' => 'TFMwdFVsTkJMUzB0SUdGelpHWmhjMlJtWVhOa1ptRnpaR1poYzJSbQ==',
 ];

--- a/tests/Domain/data/key_data_valid.php
+++ b/tests/Domain/data/key_data_valid.php
@@ -4,5 +4,5 @@ return [
     'protocol' => 3,
     'flags' => 256,
     'algorithm' => 10,
-    'publicKey' => 'LS0tUlNBLS0tIGFzZGZhc2RmYXNkZmFzZGZhc2Rm',
+    'publicKey' => 'TFMwdFVsTkJMUzB0SUdGelpHWmhjMlJtWVhOa1ptRnpaR1poYzJSbQ==',
 ];


### PR DESCRIPTION
If you used the `publicKey` property in the KeyData the public key would be returned base64 decoded. 

It would then **only** encode it again if you call `toArray()`. We should instead store the public key "as is" in the property.

Also updated the test + test data so it uses a base64 encoded string.