### PR TITLE
Fix process api

### DIFF
--- a/src/Domain/Billable.php
+++ b/src/Domain/Billable.php
@@ -34,7 +34,7 @@ final class Billable implements DomainObjectInterface
             $data['product'],
             $data['action'],
             $data['quantity'],
-            $data['amount'],
+            $data['amount'] ?? 0,
             $data['providerName']
         );
     }

--- a/src/Domain/Enum/ProcessStatusEnum.php
+++ b/src/Domain/Enum/ProcessStatusEnum.php
@@ -5,16 +5,16 @@ namespace SandwaveIo\RealtimeRegister\Domain\Enum;
 
 class ProcessStatusEnum extends AbstractEnum
 {
-    private const STATUS_NEW = 'NEW';
-    private const STATUS_VALIDATED = 'VALIDATED';
-    private const STATUS_RUNNING = 'RUNNING';
-    private const STATUS_COMPLETED = 'COMPLETED';
-    private const STATUS_INVALID = 'INVALID';
-    private const STATUS_CANCELLED = 'CANCELLED';
-    private const STATUS_FAILED = 'FAILED';
-    private const STATUS_IN_DOUBT = 'IN_DOUBT';
-    private const STATUS_SCHEDULED = 'SCHEDULED';
-    private const STATUS_SUSPENDED = 'SUSPENDED';
+    const STATUS_NEW = 'NEW';
+    const STATUS_VALIDATED = 'VALIDATED';
+    const STATUS_RUNNING = 'RUNNING';
+    const STATUS_COMPLETED = 'COMPLETED';
+    const STATUS_INVALID = 'INVALID';
+    const STATUS_CANCELLED = 'CANCELLED';
+    const STATUS_FAILED = 'FAILED';
+    const STATUS_IN_DOUBT = 'IN_DOUBT';
+    const STATUS_SCHEDULED = 'SCHEDULED';
+    const STATUS_SUSPENDED = 'SUSPENDED';
 
     protected static array $values = [
       ProcessStatusEnum::STATUS_NEW,

--- a/src/Domain/Enum/ResumeTypeEnum.php
+++ b/src/Domain/Enum/ResumeTypeEnum.php
@@ -6,12 +6,12 @@ namespace SandwaveIo\RealtimeRegister\Domain\Enum;
 
 class ResumeTypeEnum extends AbstractEnum
 {
-    private const TYPE_PROVIDER = 'PROVIDER';
-    private const TYPE_TIMER = 'TIMER';
-    private const TYPE_MANUAL = 'MANUAL';
-    private const TYPE_INTERNAL = 'INTERNAL';
-    private const TYPE_RESEND = 'RESEND';
-    private const TYPE_CANCEL = 'CANCEL';
+    const TYPE_PROVIDER = 'PROVIDER';
+    const TYPE_TIMER = 'TIMER';
+    const TYPE_MANUAL = 'MANUAL';
+    const TYPE_INTERNAL = 'INTERNAL';
+    const TYPE_RESEND = 'RESEND';
+    const TYPE_CANCEL = 'CANCEL';
 
     protected static array $values = [
         ResumeTypeEnum::TYPE_PROVIDER,

--- a/src/Domain/NotificationPoll.php
+++ b/src/Domain/NotificationPoll.php
@@ -4,10 +4,10 @@ namespace SandwaveIo\RealtimeRegister\Domain;
 
 final class NotificationPoll implements DomainObjectInterface
 {
-    public string $count;
+    public int $count;
     public ?Notification $notification;
 
-    private function __construct(string $count, ?Notification $notification)
+    private function __construct(int $count, ?Notification $notification)
     {
         $this->count = $count;
         $this->notification = $notification;

--- a/tests/Domain/data/billable_valid_no_amount.php
+++ b/tests/Domain/data/billable_valid_no_amount.php
@@ -1,8 +1,0 @@
-<?php declare(strict_types = 1);
-
-return [
-    'product' => '.nl',
-    'action' => 'TRANSFER',
-    'quantity' => 1,
-    'providerName' => 'sidn',
-];

--- a/tests/Domain/data/billable_valid_no_amount.php
+++ b/tests/Domain/data/billable_valid_no_amount.php
@@ -4,6 +4,5 @@ return [
     'product' => '.nl',
     'action' => 'TRANSFER',
     'quantity' => 1,
-    'amount' => 1,
     'providerName' => 'sidn',
 ];

--- a/tests/Domain/data/notification_poll_invalid_count.php
+++ b/tests/Domain/data/notification_poll_invalid_count.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
 return [
-    'count' => 1,
+    'count' => '1',
     'notification' => include __DIR__ . '/notification_valid.php',
 ];

--- a/tests/Domain/data/notification_poll_valid.php
+++ b/tests/Domain/data/notification_poll_valid.php
@@ -1,6 +1,6 @@
 <?php declare(strict_types = 1);
 
 return [
-    'count' => '1',
+    'count' => 1,
     'notification' => include __DIR__ . '/notification_valid.php',
 ];

--- a/tests/Domain/data/notification_poll_valid_only_required.php
+++ b/tests/Domain/data/notification_poll_valid_only_required.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types = 1);
 
 return [
-    'count' => '1',
+    'count' => 1,
 ];

--- a/tests/Domain/data/process_valid.php
+++ b/tests/Domain/data/process_valid.php
@@ -40,6 +40,6 @@ return  [
     ],
     'billables' => [
         include __DIR__ . '/billable_valid.php',
-        include __DIR__ . '/billable_valid.php',
+        include __DIR__ . '/billable_valid_no_amount.php',
     ],
 ];

--- a/tests/Domain/data/process_valid.php
+++ b/tests/Domain/data/process_valid.php
@@ -40,6 +40,6 @@ return  [
     ],
     'billables' => [
         include __DIR__ . '/billable_valid.php',
-        include __DIR__ . '/billable_valid_no_amount.php',
+        include __DIR__ . '/billable_valid.php',
     ],
 ];


### PR DESCRIPTION
- Constants in ENUMs should be public
- Billable amount key is not set when it's zero
- Notification count in the response is an integer, see: https://dm.realtimeregister.com/docs/api/notifications/poll