### PR TITLE
Allow filtering parameters in list methods

### DIFF
--- a/src/Api/BrandsApi.php
+++ b/src/Api/BrandsApi.php
@@ -25,7 +25,8 @@ final class BrandsApi extends AbstractApi
         string $customer,
         ?int $limit = null,
         ?int $offset = null,
-        ?string $search = null
+        ?string $search = null,
+        ?array $parameters = null
     ): BrandCollection {
         $query = [];
         if (! is_null($limit)) {
@@ -36,6 +37,9 @@ final class BrandsApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get("/v2/customers/{$customer}/brands", $query);
@@ -195,7 +199,8 @@ final class BrandsApi extends AbstractApi
         string $brand,
         ?int $limit = null,
         ?int $offset = null,
-        ?string $search = null
+        ?string $search = null,
+        ?array $parameters = null
     ): TemplateCollection {
         $query = [];
         if (! is_null($limit)) {
@@ -206,6 +211,9 @@ final class BrandsApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get("/v2/customers/{$customer}/brands/{$brand}/templates", $query);

--- a/src/Api/ContactsApi.php
+++ b/src/Api/ContactsApi.php
@@ -11,8 +11,13 @@ use SandwaveIo\RealtimeRegister\Domain\CountryCollection;
 final class ContactsApi extends AbstractApi
 {
     /* @see https://dm.realtimeregister.com/docs/api/contacts/list */
-    public function list(string $customer, ?int $limit = null, ?int $offset = null, ?string $search = null): ContactCollection
-    {
+    public function list(
+        string $customer,
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $search = null,
+        ?array $parameters = null
+    ): ContactCollection {
         $query = [];
         if (! is_null($limit)) {
             $query['limit'] = $limit;
@@ -22,6 +27,9 @@ final class ContactsApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get("v2/customers/{$customer}/contacts", $query);
@@ -230,8 +238,12 @@ final class ContactsApi extends AbstractApi
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/contacts/list */
-    public function listCountries(?int $limit = null, ?int $offset = null, ?string $search = null): CountryCollection
-    {
+    public function listCountries(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $search = null,
+        ?array $parameters = null
+    ): CountryCollection {
         $query = [];
         if (! is_null($limit)) {
             $query['limit'] = $limit;
@@ -241,6 +253,9 @@ final class ContactsApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get('v2/countries', $query);

--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -25,8 +25,12 @@ final class DomainsApi extends AbstractApi
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/domains/list */
-    public function list(?int $limit = null, ?int $offset = null, ?string $search = null): DomainDetailsCollection
-    {
+    public function list(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $search = null,
+        ?array $parameters = null
+    ): DomainDetailsCollection {
         $query = [];
         if (! is_null($limit)) {
             $query['limit'] = $limit;
@@ -36,6 +40,9 @@ final class DomainsApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get('v2/domains', $query);

--- a/src/Api/NotificationsApi.php
+++ b/src/Api/NotificationsApi.php
@@ -20,7 +20,8 @@ final class NotificationsApi extends AbstractApi
         string $customer,
         ?int $limit = null,
         ?int $offset = null,
-        ?string $search = null
+        ?string $search = null,
+        ?array $parameters = null
     ): NotificationCollection {
         $query = [];
         if (! is_null($limit)) {
@@ -31,6 +32,9 @@ final class NotificationsApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get("v2/customers/{$customer}/notifications", $query);

--- a/src/Api/ProcessesApi.php
+++ b/src/Api/ProcessesApi.php
@@ -28,14 +28,19 @@ final class ProcessesApi extends AbstractApi
     /**
      * @see https://dm.yoursrs-ote.com/docs/api/processes/list
      *
-     * @param int|null    $limit
-     * @param int|null    $offset
-     * @param string|null $search
+     * @param int|null              $limit
+     * @param int|null              $offset
+     * @param string|null           $search
+     * @param array<string, string> $parameters
      *
      * @return ProcessCollection
      */
-    public function list(?int $limit = null, ?int $offset = null, ?string $search = null): ProcessCollection
-    {
+    public function list(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $search = null,
+        ?array $parameters = null
+    ): ProcessCollection {
         $query = [];
         if (! is_null($limit)) {
             $query['limit'] = $limit;
@@ -45,6 +50,9 @@ final class ProcessesApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get('v2/processes', $query);

--- a/src/Api/ProvidersApi.php
+++ b/src/Api/ProvidersApi.php
@@ -20,7 +20,8 @@ final class ProvidersApi extends AbstractApi
     public function list(
         ?int $limit = null,
         ?int $offset = null,
-        ?string $search = null
+        ?string $search = null,
+        ?array $parameters = null
     ): ProviderCollection {
         $query = [];
         if (! is_null($limit)) {
@@ -31,6 +32,9 @@ final class ProvidersApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get('v2/providers', $query);
@@ -47,7 +51,8 @@ final class ProvidersApi extends AbstractApi
     public function listDowntimes(
         ?int $limit = null,
         ?int $offset = null,
-        ?string $search = null
+        ?string $search = null,
+        ?array $parameters = null
     ): DowntimeCollection {
         $query = [];
         if (! is_null($limit)) {
@@ -58,6 +63,9 @@ final class ProvidersApi extends AbstractApi
         }
         if (! is_null($search)) {
             $query['q'] = $search;
+        }
+        if (! is_null($parameters)) {
+            $query = array_merge($parameters, $query);
         }
 
         $response = $this->client->get('v2/providers/downtime', $query);

--- a/tests/Clients/BrandsApiListTemplatesTest.php
+++ b/tests/Clients/BrandsApiListTemplatesTest.php
@@ -68,7 +68,7 @@ class BrandsApiListTemplatesTest extends TestCase
         $searchTextOnFields = 'search';
 
         $parameters = [
-            'name' => 'EMAIL_HEADER'
+            'name' => 'EMAIL_HEADER',
         ];
 
         $sdk = MockedClientFactory::makeSdk(
@@ -89,7 +89,7 @@ class BrandsApiListTemplatesTest extends TestCase
                 'name' => 'EMAIL_HEADER',
                 'limit' => '10',
                 'offset' => '0',
-                'q' => 'search'
+                'q' => 'search',
             ])
         );
 

--- a/tests/Clients/BrandsApiListTemplatesTest.php
+++ b/tests/Clients/BrandsApiListTemplatesTest.php
@@ -60,4 +60,40 @@ class BrandsApiListTemplatesTest extends TestCase
         $response = $sdk->brands->listTemplates($customerHandle, $brandHandle, 10, 0, $searchTextOnFields);
         $this->assertInstanceOf(TemplateCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $customerHandle = 'customertestname';
+        $brandHandle = 'brandtestname';
+        $searchTextOnFields = 'search';
+
+        $parameters = [
+            'name' => 'EMAIL_HEADER'
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/template_valid.php',
+                    include __DIR__ . '/../Domain/data/template_valid.php',
+                    include __DIR__ . '/../Domain/data/template_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', "/v2/customers/{$customerHandle}/brands/{$brandHandle}/templates", $this, [
+                'name' => 'EMAIL_HEADER',
+                'limit' => '10',
+                'offset' => '0',
+                'q' => 'search'
+            ])
+        );
+
+        $response = $sdk->brands->listTemplates($customerHandle, $brandHandle, 10, 0, $searchTextOnFields, $parameters);
+        $this->assertInstanceOf(TemplateCollection::class, $response);
+    }
 }

--- a/tests/Clients/BrandsApiListTest.php
+++ b/tests/Clients/BrandsApiListTest.php
@@ -58,4 +58,40 @@ class BrandsApiListTest extends TestCase
         $response = $sdk->brands->list($customerHandle, 3, 0, $searchTextOnFields);
         $this->assertInstanceOf(BrandCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $customerHandle = 'customertestname';
+        $parameters = [
+            'city' => 'testcity',
+            'country:in' => 'NL,BE'
+        ];
+        $search = 'search';
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/brand_valid.php',
+                    include __DIR__ . '/../Domain/data/brand_valid.php',
+                    include __DIR__ . '/../Domain/data/brand_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', "/v2/customers/{$customerHandle}/brands", $this, [
+                'city' => 'testcity',
+                'country:in' => 'NL,BE',
+                'limit' => '3',
+                'offset' => '0',
+                'q' => 'search'
+            ])
+        );
+
+        $response = $sdk->brands->list($customerHandle, 3, 0, $search, $parameters);
+        $this->assertInstanceOf(BrandCollection::class, $response);
+    }
 }

--- a/tests/Clients/BrandsApiListTest.php
+++ b/tests/Clients/BrandsApiListTest.php
@@ -64,7 +64,7 @@ class BrandsApiListTest extends TestCase
         $customerHandle = 'customertestname';
         $parameters = [
             'city' => 'testcity',
-            'country:in' => 'NL,BE'
+            'country:in' => 'NL,BE',
         ];
         $search = 'search';
 
@@ -87,7 +87,7 @@ class BrandsApiListTest extends TestCase
                 'country:in' => 'NL,BE',
                 'limit' => '3',
                 'offset' => '0',
-                'q' => 'search'
+                'q' => 'search',
             ])
         );
 

--- a/tests/Clients/ContactsApiListCountriesTest.php
+++ b/tests/Clients/ContactsApiListCountriesTest.php
@@ -57,7 +57,7 @@ class ContactsApiListCountriesTest extends TestCase
     public function test_list_with_search_and_parameters(): void
     {
         $parameters = [
-            'code' => 'NL'
+            'code' => 'NL',
         ];
 
         $sdk = MockedClientFactory::makeSdk(
@@ -78,7 +78,7 @@ class ContactsApiListCountriesTest extends TestCase
                 'code' => 'NL',
                 'limit' => '10',
                 'offset' => '0',
-                'q' => 'nl'
+                'q' => 'nl',
             ])
         );
 

--- a/tests/Clients/ContactsApiListCountriesTest.php
+++ b/tests/Clients/ContactsApiListCountriesTest.php
@@ -53,4 +53,36 @@ class ContactsApiListCountriesTest extends TestCase
         $response = $sdk->contacts->listCountries(10, 0, 'nl');
         $this->assertInstanceOf(CountryCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'code' => 'NL'
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/country_valid.php',
+                    include __DIR__ . '/../Domain/data/country_valid.php',
+                    include __DIR__ . '/../Domain/data/country_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/countries', $this, [
+                'code' => 'NL',
+                'limit' => '10',
+                'offset' => '0',
+                'q' => 'nl'
+            ])
+        );
+
+        $response = $sdk->contacts->listCountries(10, 0, 'nl', $parameters);
+        $this->assertInstanceOf(CountryCollection::class, $response);
+    }
 }

--- a/tests/Clients/ContactsApiListTest.php
+++ b/tests/Clients/ContactsApiListTest.php
@@ -57,7 +57,7 @@ class ContactsApiListTest extends TestCase
     public function test_list_with_search_and_parameters(): void
     {
         $parameters = [
-            'organization' => 'testorg'
+            'organization' => 'testorg',
         ];
 
         $sdk = MockedClientFactory::makeSdk(
@@ -78,7 +78,7 @@ class ContactsApiListTest extends TestCase
                 'organization' => 'testorg',
                 'limit' => '3',
                 'offset' => '0',
-                'q' => 'john'
+                'q' => 'john',
             ])
         );
 

--- a/tests/Clients/ContactsApiListTest.php
+++ b/tests/Clients/ContactsApiListTest.php
@@ -53,4 +53,36 @@ class ContactsApiListTest extends TestCase
         $response = $sdk->contacts->list('johndoe', 3, 0, 'john');
         $this->assertInstanceOf(ContactCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'organization' => 'testorg'
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/contact_valid.php',
+                    include __DIR__ . '/../Domain/data/contact_valid.php',
+                    include __DIR__ . '/../Domain/data/contact_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/customers/johndoe/contacts', $this, [
+                'organization' => 'testorg',
+                'limit' => '3',
+                'offset' => '0',
+                'q' => 'john'
+            ])
+        );
+
+        $response = $sdk->contacts->list('johndoe', 3, 0, 'john', $parameters);
+        $this->assertInstanceOf(ContactCollection::class, $response);
+    }
 }

--- a/tests/Clients/DomainsApiListTest.php
+++ b/tests/Clients/DomainsApiListTest.php
@@ -57,7 +57,7 @@ class DomainsApiListTest extends TestCase
     public function test_list_with_search_and_parameters(): void
     {
         $parameters = [
-            'registrant' => 'testregistrant'
+            'registrant' => 'testregistrant',
         ];
 
         $sdk = MockedClientFactory::makeSdk(
@@ -78,7 +78,7 @@ class DomainsApiListTest extends TestCase
                 'registrant' => 'testregistrant',
                 'limit' => '3',
                 'offset' => '0',
-                'q' => 'john'
+                'q' => 'john',
             ])
         );
 

--- a/tests/Clients/DomainsApiListTest.php
+++ b/tests/Clients/DomainsApiListTest.php
@@ -53,4 +53,36 @@ class DomainsApiListTest extends TestCase
         $response = $sdk->domains->list(3, 0, 'john');
         $this->assertInstanceOf(DomainDetailsCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'registrant' => 'testregistrant'
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/domain_details_valid.php',
+                    include __DIR__ . '/../Domain/data/domain_details_valid.php',
+                    include __DIR__ . '/../Domain/data/domain_details_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/domains', $this, [
+                'registrant' => 'testregistrant',
+                'limit' => '3',
+                'offset' => '0',
+                'q' => 'john'
+            ])
+        );
+
+        $response = $sdk->domains->list(3, 0, 'john', $parameters);
+        $this->assertInstanceOf(DomainDetailsCollection::class, $response);
+    }
 }

--- a/tests/Clients/NotificationsApiListTest.php
+++ b/tests/Clients/NotificationsApiListTest.php
@@ -53,4 +53,36 @@ class NotificationsApiListTest extends TestCase
         $response = $sdk->notifications->list('johndoe', 3, 0, 'john');
         $this->assertInstanceOf(NotificationCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'notificationType' => 'test'
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/notification_valid.php',
+                    include __DIR__ . '/../Domain/data/notification_valid.php',
+                    include __DIR__ . '/../Domain/data/notification_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/customers/johndoe/notifications', $this, [
+                'notificationType' => 'test',
+                'limit' => '3',
+                'offset' => '0',
+                'q' => 'john'
+            ])
+        );
+
+        $response = $sdk->notifications->list('johndoe', 3, 0, 'john', $parameters);
+        $this->assertInstanceOf(NotificationCollection::class, $response);
+    }
 }

--- a/tests/Clients/NotificationsApiListTest.php
+++ b/tests/Clients/NotificationsApiListTest.php
@@ -57,7 +57,7 @@ class NotificationsApiListTest extends TestCase
     public function test_list_with_search_and_parameters(): void
     {
         $parameters = [
-            'notificationType' => 'test'
+            'notificationType' => 'test',
         ];
 
         $sdk = MockedClientFactory::makeSdk(
@@ -78,7 +78,7 @@ class NotificationsApiListTest extends TestCase
                 'notificationType' => 'test',
                 'limit' => '3',
                 'offset' => '0',
-                'q' => 'john'
+                'q' => 'john',
             ])
         );
 

--- a/tests/Clients/ProcessesApiListTest.php
+++ b/tests/Clients/ProcessesApiListTest.php
@@ -68,7 +68,7 @@ class ProcessesApiListTest extends TestCase
         $parameters = [
             'type' => 'incomingTransfer',
             'status' => 'completed',
-            'order' => '-updatedDate'
+            'order' => '-updatedDate',
         ];
 
         /** @var string $responseBody */
@@ -95,7 +95,7 @@ class ProcessesApiListTest extends TestCase
                 'order' => '-updatedDate',
                 'limit' => '2',
                 'offset' => '0',
-                'q' => 'search'
+                'q' => 'search',
             ])
         );
 

--- a/tests/Clients/ProcessesApiListTest.php
+++ b/tests/Clients/ProcessesApiListTest.php
@@ -62,4 +62,43 @@ class ProcessesApiListTest extends TestCase
 
         $sdk->processes->list(2, 0, 'identifier:eq=something');
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'type' => 'incomingTransfer',
+            'status' => 'completed',
+            'order' => '-updatedDate'
+        ];
+
+        /** @var string $responseBody */
+        $responseBody = json_encode(
+            [
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/process_valid.php',
+                    include __DIR__ . '/../Domain/data/process_valid.php',
+                ],
+                'pagination' => [
+                    'total' => 2,
+                    'offset' => 0,
+                    'limit' => 2,
+                ],
+            ]
+        );
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            $responseBody,
+            MockedClientFactory::assertRoute('GET', 'v2/processes', $this, [
+                'type' => 'incomingTransfer',
+                'status' => 'completed',
+                'order' => '-updatedDate',
+                'limit' => '2',
+                'offset' => '0',
+                'q' => 'search'
+            ])
+        );
+
+        $sdk->processes->list(2, 0, 'search', $parameters);
+    }
 }

--- a/tests/Clients/ProvidersApiListDowntimesTest.php
+++ b/tests/Clients/ProvidersApiListDowntimesTest.php
@@ -57,7 +57,7 @@ class ProvidersApiListDowntimesTest extends TestCase
     public function test_list_with_search_and_parameters(): void
     {
         $parameters = [
-            'name' => 'test'
+            'name' => 'test',
         ];
 
         $sdk = MockedClientFactory::makeSdk(
@@ -78,7 +78,7 @@ class ProvidersApiListDowntimesTest extends TestCase
                 'name' => 'test',
                 'limit' => '10',
                 'offset' => '0',
-                'q' => 'test'
+                'q' => 'test',
             ])
         );
 

--- a/tests/Clients/ProvidersApiListDowntimesTest.php
+++ b/tests/Clients/ProvidersApiListDowntimesTest.php
@@ -53,4 +53,36 @@ class ProvidersApiListDowntimesTest extends TestCase
         $response = $sdk->providers->listDowntimes(10, 0, '');
         $this->assertInstanceOf(DowntimeCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'name' => 'test'
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                    include __DIR__ . '/../Domain/data/downtime_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/providers/downtime', $this, [
+                'name' => 'test',
+                'limit' => '10',
+                'offset' => '0',
+                'q' => 'test'
+            ])
+        );
+
+        $response = $sdk->providers->listDowntimes(10, 0, 'test', $parameters);
+        $this->assertInstanceOf(DowntimeCollection::class, $response);
+    }
 }

--- a/tests/Clients/ProvidersApiListTest.php
+++ b/tests/Clients/ProvidersApiListTest.php
@@ -57,7 +57,7 @@ class ProvidersApiListTest extends TestCase
     public function test_list_with_search_and_parameters(): void
     {
         $parameters = [
-            'name:like' => 'testname'
+            'name:like' => 'testname',
         ];
 
         $sdk = MockedClientFactory::makeSdk(
@@ -78,7 +78,7 @@ class ProvidersApiListTest extends TestCase
                 'name:like' => 'testname',
                 'limit' => '3',
                 'offset' => '0',
-                'q' => 'providername'
+                'q' => 'providername',
             ])
         );
 

--- a/tests/Clients/ProvidersApiListTest.php
+++ b/tests/Clients/ProvidersApiListTest.php
@@ -53,4 +53,36 @@ class ProvidersApiListTest extends TestCase
         $response = $sdk->providers->list(3, 0, 'providername');
         $this->assertInstanceOf(ProviderCollection::class, $response);
     }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'name:like' => 'testname'
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                    include __DIR__ . '/../Domain/data/provider_valid.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/providers', $this, [
+                'name:like' => 'testname',
+                'limit' => '3',
+                'offset' => '0',
+                'q' => 'providername'
+            ])
+        );
+
+        $response = $sdk->providers->list(3, 0, 'providername', $parameters);
+        $this->assertInstanceOf(ProviderCollection::class, $response);
+    }
 }

--- a/tests/Helpers/MockedClientFactory.php
+++ b/tests/Helpers/MockedClientFactory.php
@@ -16,12 +16,17 @@ class MockedClientFactory
 {
     const API_KEY = 'bigseretdonttellanyone';
 
-    public static function assertRoute(string $method, string $route, TestCase $testCase): callable
+    public static function assertRoute(string $method, string $route, TestCase $testCase, ?array $expectedParameters = null): callable
     {
-        return function (RequestInterface $request) use ($method, $route, $testCase) {
+        return function (RequestInterface $request) use ($method, $route, $testCase, $expectedParameters) {
             $testCase->assertSame(strtoupper($method), strtoupper($request->getMethod()));
             $testCase->assertSame($route, $request->getUri()->getPath());
             $testCase->assertSame('ApiKey ' . static::API_KEY, $request->getHeader('Authorization')[0]);
+
+            if (null !== $expectedParameters) {
+                parse_str($request->getUri()->getQuery(), $parameters);
+                $testCase->assertSame($expectedParameters, $parameters);
+            }
         };
     }
 


### PR DESCRIPTION
List calls allow you to filter the request:
https://dm.realtimeregister.com/docs/api/listings#filtering

This requires the list methods to allow variable key names. This commit enables these filters. 

Example for filtering 100 processes with an ID greater than 50:

```
$parameters = [
  'id:gt' => 50
];

$list = $client->processes->list(100, 0, null, $parameters);
```