### PR TITLE
Fix language codes

### DIFF
--- a/src/Domain/LanguageCode.php
+++ b/src/Domain/LanguageCode.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class LanguageCode implements DomainObjectInterface
+{
+    public string $name;
+    public ?string $allowedCharacters;
+
+    private function __construct(string $name, ?string $allowedCharacters)
+    {
+        $this->name = $name;
+        $this->allowedCharacters = $allowedCharacters;
+    }
+
+    public static function fromArray(array $json): LanguageCode
+    {
+        return new LanguageCode(
+            $json['name'],
+            $json['allowedCharacters'] ?? null
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name'              => $this->name,
+            'allowedCharacters' => $this->allowedCharacters,
+        ], function ($x) {
+            return ! is_null($x);
+        });
+    }
+}

--- a/src/Domain/LanguageCodes.php
+++ b/src/Domain/LanguageCodes.php
@@ -26,11 +26,6 @@ final class LanguageCodes implements ArrayAccess, Countable
         return new self($entities);
     }
 
-    public static function parseChild(array $json): LanguageCode
-    {
-        return LanguageCode::fromArray($json);
-    }
-
     public function toArray(): array
     {
         $languageCodesArray = [];

--- a/src/Domain/LanguageCodes.php
+++ b/src/Domain/LanguageCodes.php
@@ -2,32 +2,70 @@
 
 namespace SandwaveIo\RealtimeRegister\Domain;
 
-final class LanguageCodes implements DomainObjectInterface
-{
-    public string $name;
-    public ?string $allowedCharacters;
+use ArrayAccess;
+use Countable;
 
-    private function __construct(string $name, ?string $allowedCharacters)
+final class LanguageCodes implements ArrayAccess, Countable
+{
+    /** @var array<string, LanguageCode> */
+    public array $entities;
+
+    private function __construct(array $entities)
     {
-        $this->name = $name;
-        $this->allowedCharacters = $allowedCharacters;
+        $this->entities = $entities;
     }
 
-    public static function fromArray(array $json): LanguageCodes
+    public static function fromArray(array $json): self
     {
-        return new LanguageCodes(
-            $json['name'],
-            $json['allowedCharacters'] ?? null
-        );
+        $entities = [];
+
+        foreach ($json as $countryCode => $languageCode) {
+            $entities[$countryCode] = LanguageCode::fromArray($languageCode);
+        }
+
+        return new self($entities);
+    }
+
+    public static function parseChild(array $json): LanguageCode
+    {
+        return LanguageCode::fromArray($json);
     }
 
     public function toArray(): array
     {
-        return array_filter([
-            'name'              => $this->name,
-            'allowedCharacters' => $this->allowedCharacters,
-        ], function ($x) {
-            return ! is_null($x);
-        });
+        $languageCodesArray = [];
+
+        foreach ($this->entities as $countryCode => $languageCode) {
+            $languageCodesArray[$countryCode] = $languageCode->toArray();
+        }
+
+        return $languageCodesArray;
+    }
+
+    public function offsetExists($offset): bool
+    {
+        return isset($this->entities[$offset]);
+    }
+
+    public function offsetGet($offset): ?LanguageCode
+    {
+        return $this->entities[$offset] ?? null;
+    }
+
+    public function offsetSet($offset, $value): void
+    {
+        if (is_string($offset) && $value instanceof LanguageCode) {
+            $this->entities[$offset] = $value;
+        }
+    }
+
+    public function offsetUnset($offset): void
+    {
+        unset($this->entities[$offset]);
+    }
+
+    public function count(): int
+    {
+        return count($this->entities);
     }
 }

--- a/tests/Clients/TLDsApiInfoTest.php
+++ b/tests/Clients/TLDsApiInfoTest.php
@@ -2,21 +2,52 @@
 
 namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 
+use PHPUnit\Framework\Assert;
 use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\LanguageCodes;
 use SandwaveIo\RealtimeRegister\Domain\TLDInfo;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class TLDsApiInfoTest extends TestCase
 {
-    public function test_info(): void
+    public function test_info_com(): void
     {
+        $json = file_get_contents(__DIR__ . '/../Domain/data/tldinfo_com.json');
+
+        assert(is_string($json));
+
         $sdk = MockedClientFactory::makeSdk(
             200,
-            json_encode(include __DIR__ . '/../Domain/data/tldinfo.php'),
+            $json,
+            MockedClientFactory::assertRoute('GET', 'v2/tlds/com/info', $this)
+        );
+
+        $response = $sdk->tlds->info('com');
+        $this->assertInstanceOf(TLDInfo::class, $response);
+
+        $languageCodes = $response->metadata->domainSyntax->languageCodes;
+
+        assert($languageCodes !== null);
+
+        Assert::assertInstanceOf(LanguageCodes::class, $languageCodes);
+        Assert::assertSame(113, $languageCodes->count());
+    }
+
+    public function test_info_nl(): void
+    {
+        $json = file_get_contents(__DIR__ . '/../Domain/data/tldinfo_nl.json');
+
+        assert(is_string($json));
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            $json,
             MockedClientFactory::assertRoute('GET', 'v2/tlds/nl/info', $this)
         );
 
         $response = $sdk->tlds->info('nl');
-        $this->assertInstanceOf(TLDInfo::class, $response);
+
+        Assert::assertInstanceOf(TLDInfo::class, $response);
+        Assert::assertNull($response->metadata->domainSyntax->languageCodes);
     }
 }

--- a/tests/Domain/DomainObjectTest.php
+++ b/tests/Domain/DomainObjectTest.php
@@ -20,7 +20,7 @@ use SandwaveIo\RealtimeRegister\Domain\DomainTransferStatus;
 use SandwaveIo\RealtimeRegister\Domain\Downtime;
 use SandwaveIo\RealtimeRegister\Domain\DsData;
 use SandwaveIo\RealtimeRegister\Domain\KeyData;
-use SandwaveIo\RealtimeRegister\Domain\LanguageCodes;
+use SandwaveIo\RealtimeRegister\Domain\LanguageCode;
 use SandwaveIo\RealtimeRegister\Domain\LaunchPhase;
 use SandwaveIo\RealtimeRegister\Domain\Log;
 use SandwaveIo\RealtimeRegister\Domain\Nameservers;
@@ -208,13 +208,13 @@ class DomainObjectTest extends TestCase
                 DomainSyntax::class,
                 include __DIR__ . '/data/domain_syntax.php',
             ],
-            'valid language codes (all fields)' => [
-                LanguageCodes::class,
-                include __DIR__ . '/data/language_codes.php',
+            'valid language code (all fields)' => [
+                LanguageCode::class,
+                include __DIR__ . '/data/language_code_allowed_characters.php',
             ],
-            'valid language codes (required only)' => [
-                LanguageCodes::class,
-                include __DIR__ . '/data/language_codes_required.php',
+            'valid language code (required only)' => [
+                LanguageCode::class,
+                include __DIR__ . '/data/language_code_required.php',
             ],
             'valid launch phase' => [
                 LaunchPhase::class,

--- a/tests/Domain/LanguageCodesTest.php
+++ b/tests/Domain/LanguageCodesTest.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types=1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Domain;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\LanguageCode;
+use SandwaveIo\RealtimeRegister\Domain\LanguageCodes;
+
+final class LanguageCodesTest extends TestCase
+{
+    public function test_from_array(): void
+    {
+        $languageCodeData = include __DIR__ . '/data/language_codes.php';
+
+        $languageCodes = LanguageCodes::fromArray($languageCodeData);
+
+        Assert::assertCount(2, $languageCodes);
+
+        $languageCodeDutch = $languageCodes->offsetGet('DUT');
+
+        assert($languageCodeDutch !== null);
+
+        Assert::assertInstanceOf(LanguageCode::class, $languageCodeDutch);
+        Assert::assertSame('Dutch', $languageCodeDutch->name);
+        Assert::assertSame('abcdefghijklmnopqrstuvwxyz', $languageCodeDutch->allowedCharacters);
+
+        $languageCodeEnglish = $languageCodes->offsetGet('ENG');
+
+        assert($languageCodeEnglish !== null);
+
+        Assert::assertInstanceOf(LanguageCode::class, $languageCodeEnglish);
+        Assert::assertSame('English', $languageCodeEnglish->name);
+        Assert::assertNull($languageCodeEnglish->allowedCharacters);
+
+    }
+
+    public function test_from_and_to_array(): void
+    {
+        $languageCodeData = include __DIR__ . '/data/language_codes.php';
+
+        $languageCodes = LanguageCodes::fromArray($languageCodeData);
+
+        Assert::assertSame($languageCodeData, $languageCodes->toArray());
+    }
+}

--- a/tests/Domain/LanguageCodesTest.php
+++ b/tests/Domain/LanguageCodesTest.php
@@ -43,7 +43,7 @@ final class LanguageCodesTest extends TestCase
         Assert::assertSame($languageCodeData, $languageCodes->toArray());
     }
 
-    public function test_set_unset(): void
+    public function test_set_unset_exists(): void
     {
         $languageCodeData = include __DIR__ . '/data/language_codes.php';
 
@@ -55,6 +55,8 @@ final class LanguageCodesTest extends TestCase
             ])
         );
 
+        Assert::assertTrue($languageCodes->offsetExists('GER'));
+
         $languageCodeGermany = $languageCodes->offsetGet('GER');
 
         assert($languageCodeGermany !== null);
@@ -64,5 +66,6 @@ final class LanguageCodesTest extends TestCase
         $languageCodes->offsetUnset('GER');
 
         Assert::assertNull($languageCodes->offsetGet('GER'));
+        Assert::assertFalse($languageCodes->offsetExists('GER'));
     }
 }

--- a/tests/Domain/LanguageCodesTest.php
+++ b/tests/Domain/LanguageCodesTest.php
@@ -42,4 +42,27 @@ final class LanguageCodesTest extends TestCase
 
         Assert::assertSame($languageCodeData, $languageCodes->toArray());
     }
+
+    public function test_set_unset(): void
+    {
+        $languageCodeData = include __DIR__ . '/data/language_codes.php';
+
+        $languageCodes = LanguageCodes::fromArray($languageCodeData);
+        $languageCodes->offsetSet(
+            'GER',
+            LanguageCode::fromArray([
+                'name' => 'Germany',
+            ])
+        );
+
+        $languageCodeGermany = $languageCodes->offsetGet('GER');
+
+        assert($languageCodeGermany !== null);
+
+        Assert::assertSame('Germany', $languageCodeGermany->name);
+
+        $languageCodes->offsetUnset('GER');
+
+        Assert::assertNull($languageCodes->offsetGet('GER'));
+    }
 }

--- a/tests/Domain/LanguageCodesTest.php
+++ b/tests/Domain/LanguageCodesTest.php
@@ -1,4 +1,4 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 namespace SandwaveIo\RealtimeRegister\Tests\Domain;
 
@@ -32,7 +32,6 @@ final class LanguageCodesTest extends TestCase
         Assert::assertInstanceOf(LanguageCode::class, $languageCodeEnglish);
         Assert::assertSame('English', $languageCodeEnglish->name);
         Assert::assertNull($languageCodeEnglish->allowedCharacters);
-
     }
 
     public function test_from_and_to_array(): void

--- a/tests/Domain/data/language_code_allowed_characters.php
+++ b/tests/Domain/data/language_code_allowed_characters.php
@@ -1,6 +1,6 @@
-<?php declare(strict_types=1);
+<?php declare(strict_types = 1);
 
 return [
     'name' => 'Dutch',
-    'allowedCharacters' => 'abcdefghijklmnopqrstuvwxyz'
+    'allowedCharacters' => 'abcdefghijklmnopqrstuvwxyz',
 ];

--- a/tests/Domain/data/language_code_allowed_characters.php
+++ b/tests/Domain/data/language_code_allowed_characters.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types=1);
+
+return [
+    'name' => 'Dutch',
+    'allowedCharacters' => 'abcdefghijklmnopqrstuvwxyz'
+];

--- a/tests/Domain/data/language_code_required.php
+++ b/tests/Domain/data/language_code_required.php
@@ -1,5 +1,5 @@
 <?php declare(strict_types = 1);
 
 return [
-    'name' => 'nl',
+    'name' => 'Dutch',
 ];

--- a/tests/Domain/data/language_codes.php
+++ b/tests/Domain/data/language_codes.php
@@ -3,7 +3,7 @@
 return [
     'DUT' => [
         'name' => 'Dutch',
-        'allowedCharacters' => 'abcdefghijklmnopqrstuvwxyz'
+        'allowedCharacters' => 'abcdefghijklmnopqrstuvwxyz',
     ],
     'ENG' => [
         'name' => 'English',

--- a/tests/Domain/data/language_codes.php
+++ b/tests/Domain/data/language_codes.php
@@ -1,6 +1,11 @@
 <?php declare(strict_types = 1);
 
 return [
-    'name' => 'nl',
-    'allowedCharacters' => 'abcdefghijklmnopqrstuvwxyz',
+    'DUT' => [
+        'name' => 'Dutch',
+        'allowedCharacters' => 'abcdefghijklmnopqrstuvwxyz'
+    ],
+    'ENG' => [
+        'name' => 'English',
+    ],
 ];

--- a/tests/Domain/data/tldinfo_com.json
+++ b/tests/Domain/data/tldinfo_com.json
@@ -1,0 +1,473 @@
+{
+    "metadata": {
+        "renewDomainPeriods": [
+            12,
+            24,
+            36,
+            48,
+            60,
+            72,
+            84,
+            96,
+            108,
+            120
+        ],
+        "whoisExposure": "FULL",
+        "gdprCategory": "UNKNOWN",
+        "createDomainPeriods": [
+            12,
+            24,
+            36,
+            48,
+            60,
+            72,
+            84,
+            96,
+            108,
+            120
+        ],
+        "autoRenewDomainPeriods": [
+            12
+        ],
+        "registrant": {
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "expiryDateOffset": 0,
+        "adjustableAuthCode": true,
+        "redemptionPeriod": 30,
+        "pendingDeletePeriod": 5,
+        "addGracePeriod": 5,
+        "autoRenewGracePeriod": 42,
+        "renewGracePeriod": 5,
+        "transferGracePeriod": 5,
+        "creationRequiresPreValidation": false,
+        "transferFOA": true,
+        "featuresAvailable": [
+            "RESTORE",
+            "CREATE",
+            "PRIVACY_PROTECT",
+            "RENEW",
+            "TRANSFER",
+            "UPDATE"
+        ],
+        "customAuthcodeSupport": true,
+        "adminContacts": {
+            "min": 1,
+            "max": 10,
+            "required": true,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "billingContacts": {
+            "min": 0,
+            "max": 10,
+            "required": false,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "techContacts": {
+            "min": 1,
+            "max": 10,
+            "required": true,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "nameservers": {
+            "min": 0,
+            "max": 10,
+            "required": false
+        },
+        "possibleClientDomainStatuses": [
+            "CLIENT_RENEW_PROHIBITED",
+            "CLIENT_TRANSFER_PROHIBITED",
+            "CLIENT_UPDATE_PROHIBITED",
+            "CLIENT_HOLD",
+            "CLIENT_DELETE_PROHIBITED"
+        ],
+        "domainSyntax": {
+            "minLength": 3,
+            "maxLength": 63,
+            "idnType": "UTS46",
+            "languageCodes": {
+                "AFR": {
+                    "name": "Afrikaans"
+                },
+                "ALB": {
+                    "name": "Albanian"
+                },
+                "ARA": {
+                    "name": "Arabic"
+                },
+                "ARG": {
+                    "name": "Aragonese"
+                },
+                "ARM": {
+                    "name": "Armenian"
+                },
+                "ASM": {
+                    "name": "Assamese"
+                },
+                "AST": {
+                    "name": "Asturian"
+                },
+                "AVE": {
+                    "name": "Avestan"
+                },
+                "AWA": {
+                    "name": "Awadhi"
+                },
+                "AZE": {
+                    "name": "Azerbaijani",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "BAK": {
+                    "name": "Bashkir"
+                },
+                "BAL": {
+                    "name": "Baluchi"
+                },
+                "BAN": {
+                    "name": "Balinese"
+                },
+                "BAQ": {
+                    "name": "Basque"
+                },
+                "BAS": {
+                    "name": "Basaa"
+                },
+                "BEL": {
+                    "name": "Belarusian",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "BEN": {
+                    "name": "Bengali"
+                },
+                "BHO": {
+                    "name": "Bhojpuri"
+                },
+                "BOS": {
+                    "name": "Bosnian"
+                },
+                "BUL": {
+                    "name": "Bulgarian",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "BUR": {
+                    "name": "Burmese"
+                },
+                "CAR": {
+                    "name": "Carib"
+                },
+                "CAT": {
+                    "name": "Catalan"
+                },
+                "CHE": {
+                    "name": "Chechen"
+                },
+                "CHI": {
+                    "name": "Chinese"
+                },
+                "CHV": {
+                    "name": "Chuvash"
+                },
+                "COP": {
+                    "name": "Coptic"
+                },
+                "COS": {
+                    "name": "Corsican"
+                },
+                "CZE": {
+                    "name": "Czech"
+                },
+                "DAN": {
+                    "name": "Danish"
+                },
+                "DIV": {
+                    "name": "Divehi"
+                },
+                "DOI": {
+                    "name": "Dogri"
+                },
+                "DUT": {
+                    "name": "Dutch"
+                },
+                "ENG": {
+                    "name": "English"
+                },
+                "EST": {
+                    "name": "Estonian"
+                },
+                "FAO": {
+                    "name": "Faroese"
+                },
+                "FIJ": {
+                    "name": "Fijian"
+                },
+                "FIN": {
+                    "name": "Finnish"
+                },
+                "FRE": {
+                    "name": "French"
+                },
+                "FRY": {
+                    "name": "Western Frisian"
+                },
+                "GEO": {
+                    "name": "Georgian"
+                },
+                "GER": {
+                    "name": "German"
+                },
+                "GLA": {
+                    "name": "Gaelic"
+                },
+                "GLE": {
+                    "name": "Irish"
+                },
+                "GON": {
+                    "name": "Gondi"
+                },
+                "GRE": {
+                    "name": "Greek, Modern (1453-)",
+                    "allowedCharacters": "-0123456789ͱͳ͵ͷͻͼͽΐάέήίΰαβγδεζηθικλμνξοπρςστυφχψωϊϋόύώϗϙϛϝϟϡϣϥϧϩϫϭϯϳϸϻϼ"
+                },
+                "GUJ": {
+                    "name": "Gujarati"
+                },
+                "HEB": {
+                    "name": "Hebrew"
+                },
+                "HIN": {
+                    "name": "Hindi"
+                },
+                "HUN": {
+                    "name": "Hungarian"
+                },
+                "ICE": {
+                    "name": "Icelandic"
+                },
+                "INC": {
+                    "name": "Indic"
+                },
+                "IND": {
+                    "name": "Indonesian"
+                },
+                "INH": {
+                    "name": "Ingush"
+                },
+                "ITA": {
+                    "name": "Italian"
+                },
+                "JAV": {
+                    "name": "Javanese"
+                },
+                "JPN": {
+                    "name": "Japanese"
+                },
+                "KAS": {
+                    "name": "Kashmiri"
+                },
+                "KAZ": {
+                    "name": "Kazakh"
+                },
+                "KHM": {
+                    "name": "Central Khmer"
+                },
+                "KIR": {
+                    "name": "Kirghiz"
+                },
+                "KOR": {
+                    "name": "Korean"
+                },
+                "KUR": {
+                    "name": "Kurdish",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "LAO": {
+                    "name": "Lao"
+                },
+                "LAV": {
+                    "name": "Latvian"
+                },
+                "LIT": {
+                    "name": "Lithuanian"
+                },
+                "LTZ": {
+                    "name": "Luxembourgish"
+                },
+                "MAC": {
+                    "name": "Macedonian",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "MAL": {
+                    "name": "Malayalam"
+                },
+                "MAO": {
+                    "name": "Maori"
+                },
+                "MAY": {
+                    "name": "Malay"
+                },
+                "MLT": {
+                    "name": "Maltese"
+                },
+                "MOL": {
+                    "name": "Moldavian",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "MON": {
+                    "name": "Mongolian"
+                },
+                "NEP": {
+                    "name": "Nepali"
+                },
+                "NOR": {
+                    "name": "Norwegian"
+                },
+                "ORI": {
+                    "name": "Oriya"
+                },
+                "OSS": {
+                    "name": "Ossetian"
+                },
+                "PAN": {
+                    "name": "Panjabi"
+                },
+                "PER": {
+                    "name": "Persian"
+                },
+                "POL": {
+                    "name": "Polish",
+                    "allowedCharacters": "-0123456789abcdefghijklmnopqrstuvwxyzóąćęłńśźż"
+                },
+                "POR": {
+                    "name": "Portuguese"
+                },
+                "PUS": {
+                    "name": "Pushto; Pashto"
+                },
+                "RAJ": {
+                    "name": "Rajasthani"
+                },
+                "RUM": {
+                    "name": "Romanian"
+                },
+                "RUS": {
+                    "name": "Russian",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "SAN": {
+                    "name": "Sanskrit"
+                },
+                "SCC": {
+                    "name": "Croatian/Serbian Cyrillic alphabet"
+                },
+                "SCR": {
+                    "name": "Croatian/Serbian Roman alphabet",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "SIN": {
+                    "name": "Sinhala"
+                },
+                "SLO": {
+                    "name": "Slovak"
+                },
+                "SLV": {
+                    "name": "Slovenian"
+                },
+                "SMO": {
+                    "name": "Samoan"
+                },
+                "SND": {
+                    "name": "Sindhi"
+                },
+                "SOM": {
+                    "name": "Somali"
+                },
+                "SPA": {
+                    "name": "Spanish"
+                },
+                "SRD": {
+                    "name": "Sardinian"
+                },
+                "SRP": {
+                    "name": "Serbian"
+                },
+                "SWA": {
+                    "name": "Swahili"
+                },
+                "SWE": {
+                    "name": "Swedish"
+                },
+                "SYR": {
+                    "name": "Syriac"
+                },
+                "TAM": {
+                    "name": "Tamil"
+                },
+                "TEL": {
+                    "name": "Telugu"
+                },
+                "TGK": {
+                    "name": "Tajik"
+                },
+                "THA": {
+                    "name": "Thai"
+                },
+                "TIB": {
+                    "name": "Tibetan"
+                },
+                "TUR": {
+                    "name": "Turkish"
+                },
+                "UKR": {
+                    "name": "Ukrainian",
+                    "allowedCharacters": "-0123456789абвгдежзийклмнопрстуфхцчшщъыьэюяѐёђѓєѕіїјљњћќѝўџѡѣѥѧѩѫѭѯѱѳѵѷѹѻѽѿҁ҃҄҅҆҇ҋҍҏґғҕҗҙқҝҟҡңҥҧҩҫҭүұҳҵҷҹһҽҿӂӄӆӈӊӌӎӏӑӓӕӗәӛӝӟӡӣӥӧөӫӭӯӱӳӵӷӹӻӽӿԁԃԅԇԉԋԍԏԑԓԕԗԙԛԝԟԡԣԥԧ"
+                },
+                "URD": {
+                    "name": "Urdu"
+                },
+                "UZB": {
+                    "name": "Uzbek"
+                },
+                "VIE": {
+                    "name": "Vietnamese"
+                },
+                "WEL": {
+                    "name": "Welsh"
+                },
+                "YID": {
+                    "name": "Yiddish"
+                }
+            },
+            "idnSupport": true
+        },
+        "allowedDnssecRecords": 13,
+        "allowedDnssecAlgorithms": [
+            5,
+            7,
+            8,
+            10,
+            12,
+            13,
+            14,
+            15,
+            16
+        ],
+        "transferDomainPeriods": [
+            12
+        ],
+        "transferRequiresAuthcode": true,
+        "transferSupportsAuthcode": true,
+        "premiumSupport": "NO",
+        "registrantChangeApprovalRequired": true,
+        "allowDesignatedAgent": "BOTH",
+        "validationCategory": "General"
+    },
+    "provider": "Verisign",
+    "applicableFor": [
+        "com",
+        "net"
+    ]
+}

--- a/tests/Domain/data/tldinfo_nl.json
+++ b/tests/Domain/data/tldinfo_nl.json
@@ -1,0 +1,131 @@
+{
+    "metadata": {
+        "createDomainPeriods": [
+            3,
+            12
+        ],
+        "contactProperties": [
+            {
+                "name": "legalForm",
+                "label": "Legal form",
+                "description": "The legalForm",
+                "type": "String",
+                "mandatory": false,
+                "values": {
+                    "BGG": "BGG",
+                    "EESV": "EESV",
+                    "PERSOON": "PERSOON",
+                    "OWM": "OWM",
+                    "REDR": "REDR",
+                    "NV": "NV",
+                    "VOF": "VOF",
+                    "KERK": "KERK",
+                    "COOP": "COOP",
+                    "CV": "CV",
+                    "BV": "BV",
+                    "VERENIGING": "VERENIGING",
+                    "EENMANSZAAK": "EENMANSZAAK",
+                    "STICHTING": "STICHTING",
+                    "ANDERS": "ANDERS",
+                    "BRO": "BRO",
+                    "BVI/O": "BVI/O",
+                    "MAATSCHAP": "MAATSCHAP"
+                }
+            },
+            {
+                "name": "legalFormRegNo",
+                "label": "Legal form registration number",
+                "description": "The legalFormRegNo",
+                "type": "String",
+                "mandatory": false
+            }
+        ],
+        "customAuthcodeSupport": false,
+        "possibleClientDomainStatuses": [
+            "CLIENT_HOLD"
+        ],
+        "adminContacts": {
+            "min": 1,
+            "max": 1,
+            "required": true,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "billingContacts": {
+            "min": 0,
+            "max": 1,
+            "required": false,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "techContacts": {
+            "min": 1,
+            "max": 10,
+            "required": true,
+            "organizationRequired": false,
+            "organizationAllowed": true
+        },
+        "nameservers": {
+            "min": 2,
+            "max": 13,
+            "required": false
+        },
+        "domainSyntax": {
+            "minLength": 2,
+            "maxLength": 63,
+            "idnSupport": false
+        },
+        "autoRenewDomainPeriods": [
+            1,
+            3,
+            12
+        ],
+        "allowedDnssecRecords": 4,
+        "allowedDnssecAlgorithms": [
+            3,
+            5,
+            6,
+            7,
+            8,
+            10,
+            12,
+            13,
+            14,
+            15,
+            16
+        ],
+        "transferRequiresAuthcode": true,
+        "transferSupportsAuthcode": true,
+        "premiumSupport": "NO",
+        "renewDomainPeriods": [
+            1,
+            3,
+            12
+        ],
+        "adjustableAuthCode": false,
+        "expiryDateOffset": 90000,
+        "registrantChangeApprovalRequired": false,
+        "redemptionPeriod": 40,
+        "creationRequiresPreValidation": false,
+        "transferFOA": false,
+        "featuresAvailable": [
+            "CREATE",
+            "UPDATE",
+            "RESTORE",
+            "TRANSFER"
+        ],
+        "jurisdiction": "NL",
+        "termsOfService": "https://www.sidn.nl/a/about-sidn/general-terms-and-conditions",
+        "privacyPolicy": "https://www.sidn.nl/a/nl-domain-name/sidn-and-privacy?language_id=2",
+        "whoisExposure": "NONE",
+        "gdprCategory": "EU_BASED",
+        "registrant": {
+            "organizationRequired": false,
+            "organizationAllowed": true
+        }
+    },
+    "provider": "Sidn",
+    "applicableFor": [
+        "nl"
+    ]
+}


### PR DESCRIPTION
Fixes https://github.com/sandwave-io/realtimeregister-php/issues/53

Language codes now get properly stored on the DomainSyntax model (and don't give an error anymore for .com)

The "LanguageCodes" structure differs somewhat from a Collection. (array: country code => language code) That's why I made a separate structure. 

Also added some API client tests using actual json files instead of manually creating the response as a PHP array. Should be more reliable in testing. (that's why this PR is larger than it seems)