### PR TITLE
Update notification DTO properties to be optional

### DIFF
--- a/src/Domain/Notification.php
+++ b/src/Domain/Notification.php
@@ -9,7 +9,7 @@ final class Notification implements DomainObjectInterface
     public int $id;
     public DateTime $fireDate;
     public DateTime $readDate;
-    public DateTime $acknowledgedDate;
+    public ?DateTime $acknowledgedDate;
     public string $message;
     public ?string $reason;
     public ?string $customer;
@@ -23,7 +23,7 @@ final class Notification implements DomainObjectInterface
         int $id,
         DateTime $fireDate,
         DateTime $readDate,
-        DateTime $acknowledgedDate,
+        ?DateTime $acknowledgedDate,
         string $message,
         ?string $reason,
         ?string $customer,
@@ -51,7 +51,7 @@ final class Notification implements DomainObjectInterface
             $json['id'],
             new DateTime($json['fireDate']),
             new DateTime($json['readDate']),
-            new DateTime($json['acknowledgedDate']),
+            isset($json['acknowledgedDate']) ? new DateTime($json['acknowledgedDate']) : null,
             $json['message'],
             $json['reason'] ?? null,
             $json['customer'] ?? null,
@@ -68,7 +68,7 @@ final class Notification implements DomainObjectInterface
             'id' => $this->id,
             'fireDate' => $this->fireDate->format('Y-m-d\TH:i:s\Z'),
             'readDate' => $this->readDate->format('Y-m-d\TH:i:s\Z'),
-            'acknowledgedDate' => $this->acknowledgedDate->format('Y-m-d\TH:i:s\Z'),
+            'acknowledgedDate' => $this->acknowledgedDate ? $this->acknowledgedDate->format('Y-m-d\TH:i:s\Z') : null,
             'message' => $this->message,
             'reason' => $this->reason,
             'customer' => $this->customer,

--- a/src/Domain/Notification.php
+++ b/src/Domain/Notification.php
@@ -8,7 +8,7 @@ final class Notification implements DomainObjectInterface
 {
     public int $id;
     public DateTime $fireDate;
-    public DateTime $readDate;
+    public ?DateTime $readDate;
     public ?DateTime $acknowledgedDate;
     public string $message;
     public ?string $reason;
@@ -22,7 +22,7 @@ final class Notification implements DomainObjectInterface
     private function __construct(
         int $id,
         DateTime $fireDate,
-        DateTime $readDate,
+        ?DateTime $readDate,
         ?DateTime $acknowledgedDate,
         string $message,
         ?string $reason,
@@ -50,7 +50,7 @@ final class Notification implements DomainObjectInterface
         return new Notification(
             $json['id'],
             new DateTime($json['fireDate']),
-            new DateTime($json['readDate']),
+            isset($json['readDate']) ? new DateTime($json['readDate']) : null,
             isset($json['acknowledgedDate']) ? new DateTime($json['acknowledgedDate']) : null,
             $json['message'],
             $json['reason'] ?? null,
@@ -67,7 +67,7 @@ final class Notification implements DomainObjectInterface
         return array_filter([
             'id' => $this->id,
             'fireDate' => $this->fireDate->format('Y-m-d\TH:i:s\Z'),
-            'readDate' => $this->readDate->format('Y-m-d\TH:i:s\Z'),
+            'readDate' => $this->readDate ? $this->readDate->format('Y-m-d\TH:i:s\Z') : null,
             'acknowledgedDate' => $this->acknowledgedDate ? $this->acknowledgedDate->format('Y-m-d\TH:i:s\Z') : null,
             'message' => $this->message,
             'reason' => $this->reason,

--- a/tests/Domain/data/notification_valid_only_required.php
+++ b/tests/Domain/data/notification_valid_only_required.php
@@ -4,7 +4,6 @@ return [
     'id' => 1,
     'fireDate' => '2020-08-30T01:02:03Z',
     'readDate' => '2020-08-30T01:02:03Z',
-    'acknowledgedDate' => '2020-08-30T01:02:03Z',
     'message' => 'FAKEMESSAGE',
     'eventType' => 'FAKE_EVENT_TYPE',
     'notificationType' => 'FAKE_NOTIFICATION_TYPE',

--- a/tests/Domain/data/notification_valid_only_required.php
+++ b/tests/Domain/data/notification_valid_only_required.php
@@ -3,7 +3,6 @@
 return [
     'id' => 1,
     'fireDate' => '2020-08-30T01:02:03Z',
-    'readDate' => '2020-08-30T01:02:03Z',
     'message' => 'FAKEMESSAGE',
     'eventType' => 'FAKE_EVENT_TYPE',
     'notificationType' => 'FAKE_NOTIFICATION_TYPE',


### PR DESCRIPTION
The [API documentation](https://dm.yoursrs-ote.com/docs/api/notifications/get#response) first stated incorrectly that the acknowledged and "read date" property on the notification are required, but that wasn't the case when polling or getting notifications. The documentation has been updated and this MR will make those properties optional on the notification DTO.