### PR TITLE
Add dcv parameter to reissue endpoint

### DIFF
--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -262,7 +262,8 @@ final class CertificatesApi extends AbstractApi
         ?string $postalCode = null,
         ?string $city = null,
         ?string $coc = null,
-        ?array $approver = null
+        ?array $approver = null,
+        ?array $dcv = null
     ): void {
         $payload = [
             'csr' => $csr,
@@ -298,6 +299,10 @@ final class CertificatesApi extends AbstractApi
 
         if (! is_null($approver)) {
             $payload['approver'] = $approver;
+        }
+
+        if (! is_null($dcv)) {
+            $payload['dcv'] = $dcv;
         }
 
         $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);

--- a/tests/Clients/CertificatesApiReissueCertificateTest.php
+++ b/tests/Clients/CertificatesApiReissueCertificateTest.php
@@ -3,6 +3,7 @@
 namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 
 use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\Enum\DcvTypeEnum;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class CertificatesApiReissueCertificateTest extends TestCase
@@ -25,6 +26,11 @@ class CertificatesApiReissueCertificateTest extends TestCase
             '1234AB',
             'Amsterdam',
             '12345678',
+            null,
+            [
+                'commonName' => 'www.example.com',
+                'type' => DcvTypeEnum::LOCALE_DNS,
+            ]
         );
     }
 }


### PR DESCRIPTION
Documentation: [RTR SSL reissue](https://dm.realtimeregister.com/docs/api/ssl/reissue)

DCV params can be required depending on the type of SSL that needs to get reissued and it was missing from the reissue function signature.