### PR TITLE
Return X-Process-Id from reissue endpoint

### DIFF
--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -173,7 +173,11 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates', $payload);
 
-        return $response->headers()['X-Process-Id'][0];
+        $headers = $response->headers();
+
+        assert(isset($headers['X-Process-Id']));
+
+        return $headers['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/renew */
@@ -244,7 +248,11 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/renew', $payload);
 
-        return $response->headers()['X-Process-Id'][0];
+        $headers = $response->headers();
+
+        assert(isset($headers['X-Process-Id']));
+
+        return $headers['X-Process-Id'][0];
     }
 
     /** @see https://dm.realtimeregister.com/docs/api/ssl/reissue */
@@ -303,7 +311,11 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);
 
-        return $response->headers()['X-Process-Id'][0];
+        $headers = $response->headers();
+
+        assert(isset($headers['X-Process-Id']));
+
+        return $headers['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/revoke */

--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -173,7 +173,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates', $payload);
 
-        return $response->headers()['X-Process-Id'];
+        return $response->headers()['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/renew */
@@ -244,7 +244,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/renew', $payload);
 
-        return $response->headers()['X-Process-Id'];
+        return $response->headers()['X-Process-Id'][0];
     }
 
     /** @see https://dm.realtimeregister.com/docs/api/ssl/reissue */
@@ -303,7 +303,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);
 
-        return $response->headers()['X-Process-Id'];
+        return $response->headers()['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/revoke */

--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -173,7 +173,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates', $payload);
 
-        return $response->headers()['X-Process-Id'][0];
+        return (int) $response->headers()['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/renew */
@@ -244,7 +244,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/renew', $payload);
 
-        return $response->headers()['X-Process-Id'][0];
+        return (int) $response->headers()['X-Process-Id'][0];
     }
 
     /** @see https://dm.realtimeregister.com/docs/api/ssl/reissue */
@@ -303,7 +303,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);
 
-        return $response->headers()['X-Process-Id'][0];
+        return (int) $response->headers()['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/revoke */

--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -2,6 +2,7 @@
 
 namespace SandwaveIo\RealtimeRegister\Api;
 
+use AssertionError;
 use DateTimeImmutable;
 use SandwaveIo\RealtimeRegister\Domain\Certificate;
 use SandwaveIo\RealtimeRegister\Domain\CertificateCollection;
@@ -175,7 +176,9 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        assert(isset($headers['X-Process-Id']));
+        if (! isset($headers['X-Process-Id'])) {
+            throw new AssertionError('X-Process-Id is not present in the response');
+        }
 
         return $headers['X-Process-Id'][0];
     }
@@ -250,7 +253,9 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        assert(isset($headers['X-Process-Id']));
+        if (! isset($headers['X-Process-Id'])) {
+            throw new AssertionError('X-Process-Id is not present in the response');
+        }
 
         return $headers['X-Process-Id'][0];
     }
@@ -313,7 +318,9 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        assert(isset($headers['X-Process-Id']));
+        if (! isset($headers['X-Process-Id'])) {
+            throw new AssertionError('X-Process-Id is not present in the response');
+        }
 
         return $headers['X-Process-Id'][0];
     }

--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -119,7 +119,7 @@ final class CertificatesApi extends AbstractApi
         ?string $saLanguage = null,
         ?array $approver = null,
         ?array $dcv = null
-    ): ?int {
+    ): int {
         $payload = [
             'customer' => $customer,
             'product' => $product,
@@ -173,9 +173,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates', $payload);
 
-        $headers = $response->headers();
-
-        return isset($headers['X-Process-Id']) ? $headers['X-Process-Id'][0] : null;
+        return $response->headers()['X-Process-Id'];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/renew */
@@ -194,7 +192,7 @@ final class CertificatesApi extends AbstractApi
         ?string $saLanguage = null,
         ?array $approver = null,
         ?array $dcv = null
-    ): ?int {
+    ): int {
         $payload = [
             'period' => $period,
             'csr' => $csr,
@@ -246,9 +244,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/renew', $payload);
 
-        $headers = $response->headers();
-
-        return isset($headers['X-Process-Id']) ? $headers['X-Process-Id'][0] : null;
+        return $response->headers()['X-Process-Id'];
     }
 
     /** @see https://dm.realtimeregister.com/docs/api/ssl/reissue */
@@ -264,7 +260,7 @@ final class CertificatesApi extends AbstractApi
         ?string $coc = null,
         ?array $approver = null,
         ?array $dcv = null
-    ): void {
+    ): int {
         $payload = [
             'csr' => $csr,
         ];
@@ -305,7 +301,9 @@ final class CertificatesApi extends AbstractApi
             $payload['dcv'] = $dcv;
         }
 
-        $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);
+        $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);
+
+        return $response->headers()['X-Process-Id'];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/revoke */

--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -2,7 +2,6 @@
 
 namespace SandwaveIo\RealtimeRegister\Api;
 
-use AssertionError;
 use DateTimeImmutable;
 use SandwaveIo\RealtimeRegister\Domain\Certificate;
 use SandwaveIo\RealtimeRegister\Domain\CertificateCollection;
@@ -176,9 +175,7 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        if (! isset($headers['X-Process-Id'])) {
-            throw new AssertionError('X-Process-Id is not present in the response');
-        }
+        assert(isset($headers['X-Process-Id']));
 
         return $headers['X-Process-Id'][0];
     }
@@ -253,9 +250,7 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        if (! isset($headers['X-Process-Id'])) {
-            throw new AssertionError('X-Process-Id is not present in the response');
-        }
+        assert(isset($headers['X-Process-Id']));
 
         return $headers['X-Process-Id'][0];
     }
@@ -318,9 +313,7 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        if (! isset($headers['X-Process-Id'])) {
-            throw new AssertionError('X-Process-Id is not present in the response');
-        }
+        assert(isset($headers['X-Process-Id']));
 
         return $headers['X-Process-Id'][0];
     }

--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -173,11 +173,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates', $payload);
 
-        $headers = $response->headers();
-
-        assert(isset($headers['X-Process-Id']));
-
-        return $headers['X-Process-Id'][0];
+        return $response->headers()['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/renew */
@@ -248,11 +244,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/renew', $payload);
 
-        $headers = $response->headers();
-
-        assert(isset($headers['X-Process-Id']));
-
-        return $headers['X-Process-Id'][0];
+        return $response->headers()['X-Process-Id'][0];
     }
 
     /** @see https://dm.realtimeregister.com/docs/api/ssl/reissue */
@@ -311,11 +303,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);
 
-        $headers = $response->headers();
-
-        assert(isset($headers['X-Process-Id']));
-
-        return $headers['X-Process-Id'][0];
+        return $response->headers()['X-Process-Id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/revoke */

--- a/tests/Clients/CertificatesApiReissueCertificateTest.php
+++ b/tests/Clients/CertificatesApiReissueCertificateTest.php
@@ -23,7 +23,7 @@ class CertificatesApiReissueCertificateTest extends TestCase
             MockedClientFactory::assertRoute('POST', '/v2/ssl/certificates/1/reissue', $this)
         );
 
-        $sdk->certificates->reissueCertificate(
+        $processId = $sdk->certificates->reissueCertificate(
             1,
             '-----BEGIN CERTIFICATE REQUEST-----\nMIIC6zCCAdMCAQAwgaUxCzAJBgNVBAYTAk5MMRMwEQYDVQQIDApHZWxkZXJsYW5k\nMREwDwYDVQQHDAhTaW5kZXJlbjERMA8GA1UECgwIU2FuZHdhdmUxETAPBgNVBAsM\nCEludGVybmV0MSMwIQYDVQQDDBp3d3cudGVzdGluZ2Fzc2xyZXF1ZXN0LmNvbTEj\nMCEGCSqGSIb3DQEJARYUYXJuby5ib3RAc2FuZHdhdmUuaW8wggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQDGW2yZOov0ug7d3zrnHyJtdegguLcdVSc9sbhg\nqKzwNSyQeVfvLgSqFu8glT28FAPJy1fhNydJm8WUvV29+UdiUIx7a0nWNNsBNRQ2\nglk8g+cklwemyuTPvlhvQC1RtQtoer4ibgd4TjP3/cZLHpakTRZYbz6XIsYOA7si\nlBzMfsxNwuAtB+NvJd9Guscu8yGS3cXG/K9xkQrT/uuTjLoynTjXmZXzHpEDz39/\n60F5aKbkl/OzgUYrct5on/aLUhcv1heoYah6XsxIjrtPpTFMxAA0JR3SGHnCe1rP\nyoPP5k9chQ6q+ljw9/Wgs1iVyl8DJFYWTlI0ztPaEUX+FoDFAgMBAAGgADANBgkq\nhkiG9w0BAQsFAAOCAQEAw8cD4C0yHF+vXBgTkCsclbSVj7chx37Al9qUp7r5dOdS\nsxWPFHZVyfaxWIfh/C1ydAd7gpoW2eyc51qwV0pp2Y20V+cR4PjunO+HErWCSm67\n5HVeqsGYYIW/vL0MbfrYJCSVIVB89UEDTtcZ4vdVAG0D2cwfkBV4qNlg++LATpXn\nILtgC157yLc6E8DVUEgjLEjt/xAsANQb4f0yLVSoeGHPIejRmvVQjTkz5Xk5e6vt\nsKYP2GbIIvy5xXwDKhdGVi5XpNgO5PupJyScU4C9ssLCjcF6l60y8jkZypesUwWH\n9Fh3UbrYKTu5+V99QSNz8sZXIxk2hMnqjDdttpNgtg==\n-----END CERTIFICATE REQUEST-----',
             [],
@@ -39,5 +39,7 @@ class CertificatesApiReissueCertificateTest extends TestCase
                 'type' => DcvTypeEnum::LOCALE_DNS,
             ]
         );
+
+        self::assertSame(1, $processId);
     }
 }

--- a/tests/Clients/CertificatesApiRenewCertificateTest.php
+++ b/tests/Clients/CertificatesApiRenewCertificateTest.php
@@ -23,7 +23,7 @@ class CertificatesApiRenewCertificateTest extends TestCase
             MockedClientFactory::assertRoute('POST', '/v2/ssl/certificates/1/renew', $this)
         );
 
-        $sdk->certificates->renewCertificate(
+        $processId = $sdk->certificates->renewCertificate(
             1,
             6,
             '-----BEGIN CERTIFICATE REQUEST-----\nMIIC6zCCAdMCAQAwgaUxCzAJBgNVBAYTAk5MMRMwEQYDVQQIDApHZWxkZXJsYW5k\nMREwDwYDVQQHDAhTaW5kZXJlbjERMA8GA1UECgwIU2FuZHdhdmUxETAPBgNVBAsM\nCEludGVybmV0MSMwIQYDVQQDDBp3d3cudGVzdGluZ2Fzc2xyZXF1ZXN0LmNvbTEj\nMCEGCSqGSIb3DQEJARYUYXJuby5ib3RAc2FuZHdhdmUuaW8wggEiMA0GCSqGSIb3\nDQEBAQUAA4IBDwAwggEKAoIBAQDGW2yZOov0ug7d3zrnHyJtdegguLcdVSc9sbhg\nqKzwNSyQeVfvLgSqFu8glT28FAPJy1fhNydJm8WUvV29+UdiUIx7a0nWNNsBNRQ2\nglk8g+cklwemyuTPvlhvQC1RtQtoer4ibgd4TjP3/cZLHpakTRZYbz6XIsYOA7si\nlBzMfsxNwuAtB+NvJd9Guscu8yGS3cXG/K9xkQrT/uuTjLoynTjXmZXzHpEDz39/\n60F5aKbkl/OzgUYrct5on/aLUhcv1heoYah6XsxIjrtPpTFMxAA0JR3SGHnCe1rP\nyoPP5k9chQ6q+ljw9/Wgs1iVyl8DJFYWTlI0ztPaEUX+FoDFAgMBAAGgADANBgkq\nhkiG9w0BAQsFAAOCAQEAw8cD4C0yHF+vXBgTkCsclbSVj7chx37Al9qUp7r5dOdS\nsxWPFHZVyfaxWIfh/C1ydAd7gpoW2eyc51qwV0pp2Y20V+cR4PjunO+HErWCSm67\n5HVeqsGYYIW/vL0MbfrYJCSVIVB89UEDTtcZ4vdVAG0D2cwfkBV4qNlg++LATpXn\nILtgC157yLc6E8DVUEgjLEjt/xAsANQb4f0yLVSoeGHPIejRmvVQjTkz5Xk5e6vt\nsKYP2GbIIvy5xXwDKhdGVi5XpNgO5PupJyScU4C9ssLCjcF6l60y8jkZypesUwWH\n9Fh3UbrYKTu5+V99QSNz8sZXIxk2hMnqjDdttpNgtg==\n-----END CERTIFICATE REQUEST-----',
@@ -43,5 +43,7 @@ class CertificatesApiRenewCertificateTest extends TestCase
                 'email' => 'dcv@mail.com',
             ]
         );
+
+        self::assertSame(1, $processId);
     }
 }

--- a/tests/Clients/CertificatesApiRequestCertificateTest.php
+++ b/tests/Clients/CertificatesApiRequestCertificateTest.php
@@ -21,13 +21,13 @@ class CertificatesApiRequestCertificateTest extends TestCase
                     json_encode([
                         'commonName' => 'commonname.com',
                         'requiresAttention' => false,
-                    ]),
+                    ], JSON_THROW_ON_ERROR),
                 );
             },
             MockedClientFactory::assertRoute('POST', '/v2/ssl/certificates', $this)
         );
 
-        $sdk->certificates->requestCertificate(
+        $processId = $sdk->certificates->requestCertificate(
             'customer',
             'ssl',
             6,
@@ -48,5 +48,7 @@ class CertificatesApiRequestCertificateTest extends TestCase
                 'email' => 'dcv@mail.com',
             ]
         );
+
+        self::assertSame(1, $processId);
     }
 }


### PR DESCRIPTION
Return the X-Process-Id header from the reissue endpoint since reissueing an SSL certificate also starts a new process at RTR. 

Also updated the return type from a nullable integer to a non-nullable integer, RTR will always attach the X-Process-Id header to their response when the endpoint called creates a new process on their end.

According to their docs: 
> When a requests creates a process a "X-Process-Id" header will be included in the response