### PR TITLE
Mock response object

### DIFF
--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -175,7 +175,7 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        return isset($headers['X-Process-Id']) ? $headers['X-Process-Id'][0] : null;
+        return isset($headers['X-Process-Id']) ? (int) $headers['X-Process-Id'][0] : null;
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/renew */
@@ -248,7 +248,7 @@ final class CertificatesApi extends AbstractApi
 
         $headers = $response->headers();
 
-        return isset($headers['X-Process-Id']) ? $headers['X-Process-Id'][0] : null;
+        return isset($headers['X-Process-Id']) ? (int) $headers['X-Process-Id'][0] : null;
     }
 
     /** @see https://dm.realtimeregister.com/docs/api/ssl/reissue */

--- a/tests/AuthorizedClientTest.php
+++ b/tests/AuthorizedClientTest.php
@@ -81,7 +81,9 @@ class AuthorizedClientTest extends TestCase
                 $this->assertSame(strtoupper($method), strtoupper($request->getMethod()));
                 $this->assertSame('test', $request->getUri()->getPath());
                 $this->assertSame('ApiKey bigsecretdonttellanyone', $request->getHeader('Authorization')[0]);
-        }, $logger);
+            },
+            $logger
+        );
 
         if ($exception) {
             $this->expectException($exception);

--- a/tests/Clients/CertificatesApiReissueCertificateTest.php
+++ b/tests/Clients/CertificatesApiReissueCertificateTest.php
@@ -12,7 +12,7 @@ class CertificatesApiReissueCertificateTest extends TestCase
     public function test_reissue(): void
     {
         $sdk = MockedClientFactory::makeMockedSdk(
-            function (): Response {
+            static function (): Response {
                 return new Response(
                     202,
                     [

--- a/tests/Clients/CertificatesApiReissueCertificateTest.php
+++ b/tests/Clients/CertificatesApiReissueCertificateTest.php
@@ -2,6 +2,7 @@
 
 namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\Enum\DcvTypeEnum;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
@@ -10,9 +11,15 @@ class CertificatesApiReissueCertificateTest extends TestCase
 {
     public function test_reissue(): void
     {
-        $sdk = MockedClientFactory::makeSdk(
-            202,
-            '',
+        $sdk = MockedClientFactory::makeMockedSdk(
+            function (): Response {
+                return new Response(
+                    202,
+                    [
+                        'X-Process-Id' => 1,
+                    ],
+                );
+            },
             MockedClientFactory::assertRoute('POST', '/v2/ssl/certificates/1/reissue', $this)
         );
 

--- a/tests/Clients/CertificatesApiRenewCertificateTest.php
+++ b/tests/Clients/CertificatesApiRenewCertificateTest.php
@@ -2,6 +2,7 @@
 
 namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\Enum\DcvTypeEnum;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
@@ -10,9 +11,15 @@ class CertificatesApiRenewCertificateTest extends TestCase
 {
     public function test_renew(): void
     {
-        $sdk = MockedClientFactory::makeSdk(
-            202,
-            '',
+        $sdk = MockedClientFactory::makeMockedSdk(
+            static function (): Response {
+                return new Response(
+                    202,
+                    [
+                        'X-Process-Id' => 1,
+                    ]
+                );
+            },
             MockedClientFactory::assertRoute('POST', '/v2/ssl/certificates/1/renew', $this)
         );
 

--- a/tests/Clients/CertificatesApiRequestCertificateTest.php
+++ b/tests/Clients/CertificatesApiRequestCertificateTest.php
@@ -27,7 +27,7 @@ class CertificatesApiRequestCertificateTest extends TestCase
             MockedClientFactory::assertRoute('POST', '/v2/ssl/certificates', $this)
         );
 
-        $processId = $sdk->certificates->requestCertificate(
+        $sdk->certificates->requestCertificate(
             'customer',
             'ssl',
             6,
@@ -48,7 +48,5 @@ class CertificatesApiRequestCertificateTest extends TestCase
                 'email' => 'dcv@mail.com',
             ]
         );
-
-        self::assertSame(1, $processId);
     }
 }

--- a/tests/Clients/CertificatesApiRequestCertificateTest.php
+++ b/tests/Clients/CertificatesApiRequestCertificateTest.php
@@ -2,6 +2,7 @@
 
 namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 
+use GuzzleHttp\Psr7\Response;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\Enum\DcvTypeEnum;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
@@ -10,13 +11,23 @@ class CertificatesApiRequestCertificateTest extends TestCase
 {
     public function test_request(): void
     {
-        $sdk = MockedClientFactory::makeSdk(
-            202,
-            '',
+        $sdk = MockedClientFactory::makeMockedSdk(
+            static function (): Response {
+                return new Response(
+                    202,
+                    [
+                        'X-Process-Id' => 1,
+                    ],
+                    json_encode([
+                        'commonName' => 'commonname.com',
+                        'requiresAttention' => false,
+                    ]),
+                );
+            },
             MockedClientFactory::assertRoute('POST', '/v2/ssl/certificates', $this)
         );
 
-        $sdk->certificates->requestCertificate(
+        $processId = $sdk->certificates->requestCertificate(
             'customer',
             'ssl',
             6,
@@ -32,10 +43,12 @@ class CertificatesApiRequestCertificateTest extends TestCase
             'en',
             null,
             [
-                'commonName' => 'CommonName',
+                'commonName' => 'commonname.com',
                 'type' => DcvTypeEnum::LOCALE_DNS,
                 'email' => 'dcv@mail.com',
             ]
         );
+
+        self::assertSame(1, $processId);
     }
 }


### PR DESCRIPTION
In #60 I wasn't able to mock the response headers, which is necessary to create good coverage for the tests.

Adds a function that allows you to mock the entire response object instead of only the status code & response body. I kept the `makeSdk` function for backwards compatability.

Also casted X-Process-Id header to an integer, since tests were failing because of the invalid return type.