### PR TITLE
Allow installation in laravel 9 and small fix in the pricelist response

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "php": "^7.4|^8.0",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^6.2.0|^7.0.1",
-        "psr/log": "^1.1",
+        "psr/log": "^1.1|^2.0|^3.0",
         "webmozart/assert": "^1.3.0"
     },
     "require-dev": {

--- a/src/Api/CustomersApi.php
+++ b/src/Api/CustomersApi.php
@@ -11,7 +11,7 @@ final class CustomersApi extends AbstractApi
     public function priceList(string $customer): PriceCollection
     {
         $response = $this->client->get("v2/customers/{$customer}/pricelist");
-        return PriceCollection::fromArray($response->json());
+        return PriceCollection::fromArray($response->json()['prices']);
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/customers/credits */

--- a/tests/Clients/CustomersApiListPricesTest.php
+++ b/tests/Clients/CustomersApiListPricesTest.php
@@ -13,7 +13,7 @@ class CustomersApiListPricesTest extends TestCase
         $sdk = MockedClientFactory::makeSdk(
             200,
             json_encode([
-                'entities' => [
+                'prices' => [
                     include __DIR__ . '/../Domain/data/price_valid.php',
                     include __DIR__ . '/../Domain/data/price_valid.php',
                     include __DIR__ . '/../Domain/data/price_valid.php',


### PR DESCRIPTION
Two small changes: 
- Laravel 9 has psr/log version 3, so I can't install the package by default on laravel
- The Pricelist response has [a prices key](https://dm.realtimeregister.com/docs/api/customers/pricelist) which should be used to parse the collection