### PR TITLE
Added zone info + zone update calls

### DIFF
--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -10,6 +10,8 @@ use SandwaveIo\RealtimeRegister\Domain\DomainDetails;
 use SandwaveIo\RealtimeRegister\Domain\DomainDetailsCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainRegistration;
 use SandwaveIo\RealtimeRegister\Domain\DomainTransferStatus;
+use SandwaveIo\RealtimeRegister\Domain\DomainZone;
+use SandwaveIo\RealtimeRegister\Domain\DomainZoneRecord;
 use SandwaveIo\RealtimeRegister\Domain\Enum\DomainDesignatedAgentEnum;
 use SandwaveIo\RealtimeRegister\Domain\Enum\DomainStatusEnum;
 use SandwaveIo\RealtimeRegister\Domain\KeyDataCollection;
@@ -59,6 +61,30 @@ final class DomainsApi extends AbstractApi
 
         $response = $this->client->get("v2/domains/{$domainName}/check", $query);
         return DomainAvailability::fromArray($response->json());
+    }
+
+    /* @see https://dm.realtimeregister.com/docs/api/domains/zoneinfo */
+    public function zone(string $domainName): DomainZone
+    {
+        $response = $this->client->get("v2/domains/{$domainName}/zone");
+        return DomainZone::fromArray($response->json());
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/domains/zoneupdate
+     *
+     * @param DomainZoneRecord[] $records
+     */
+    public function zoneUpdate(string $domainName, string $hostMaster, int $refresh, int $retry, int $expire, int $ttl, array $records): void
+    {
+        $this->client->post("v2/domains/{$domainName}/zone/update", [
+            'hostMaster' => $hostMaster,
+            'refresh' => $refresh,
+            'retry' => $retry,
+            'expire' => $expire,
+            'ttl' => $ttl,
+            'records' => $records,
+        ]);
     }
 
     /**

--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -75,16 +75,21 @@ final class DomainsApi extends AbstractApi
      *
      * @param DomainZoneRecord[] $records
      */
-    public function zoneUpdate(string $domainName, string $hostMaster, int $refresh, int $retry, int $expire, int $ttl, array $records): void
+    public function zoneUpdate(string $domainName, string $hostMaster, int $refresh, int $retry, int $expire, int $ttl, ?array $records = null): void
     {
-        $this->client->post("v2/domains/{$domainName}/zone/update", [
+        $data = [
             'hostMaster' => $hostMaster,
             'refresh' => $refresh,
             'retry' => $retry,
             'expire' => $expire,
             'ttl' => $ttl,
-            'records' => $records,
-        ]);
+        ];
+
+        if ($records !== null) {
+            $data['records'] = $records;
+        }
+
+        $this->client->post("v2/domains/{$domainName}/zone/update", $data);
     }
 
     /**

--- a/src/Domain/AbstractCollection.php
+++ b/src/Domain/AbstractCollection.php
@@ -32,6 +32,7 @@ abstract class AbstractCollection implements ArrayAccess, IteratorAggregate, Cou
         return isset($this->entities[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     abstract public function offsetGet($offset);
 
     public function offsetSet($offset, $value): void

--- a/src/Domain/DomainZone.php
+++ b/src/Domain/DomainZone.php
@@ -1,0 +1,65 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class DomainZone implements DomainObjectInterface
+{
+    public ?string $template;
+    public string $hostMaster;
+    public int $refresh;
+    public int $retry;
+    public int $expire;
+    public int $ttl;
+    public DomainZoneRecordCollection $defaultRecords;
+    public DomainZoneRecordCollection $records;
+
+    private function __construct(
+        ?string $template,
+        string $hostMaster,
+        int $refresh,
+        int $retry,
+        int $expire,
+        int $ttl,
+        array $defaultRecords,
+        array $records
+    ) {
+        $this->template = $template;
+        $this->hostMaster = $hostMaster;
+        $this->refresh = $refresh;
+        $this->retry = $retry;
+        $this->expire = $expire;
+        $this->ttl = $ttl;
+        $this->defaultRecords = DomainZoneRecordCollection::fromArray($defaultRecords);
+        $this->records = DomainZoneRecordCollection::fromArray($records);
+    }
+
+    public static function fromArray(array $json): DomainZone
+    {
+        return new DomainZone(
+            $json['template'] ?? null,
+            $json['hostMaster'],
+            $json['refresh'],
+            $json['retry'],
+            $json['expire'],
+            $json['ttl'],
+            $json['defaultRecords'],
+            $json['records'] ?? [],
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'template' => $this->template,
+            'hostMaster' => $this->hostMaster,
+            'refresh' => $this->refresh,
+            'retry' => $this->retry,
+            'expire' => $this->expire,
+            'ttl' => $this->ttl,
+            'defaultRecords' => $this->defaultRecords->toArray(),
+            'records' => $this->records->toArray(),
+        ], static function ($x) {
+            return $x !== null;
+        });
+    }
+}

--- a/src/Domain/DomainZone.php
+++ b/src/Domain/DomainZone.php
@@ -11,7 +11,7 @@ final class DomainZone implements DomainObjectInterface
     public int $expire;
     public int $ttl;
     public DomainZoneRecordCollection $defaultRecords;
-    public DomainZoneRecordCollection $records;
+    public ?DomainZoneRecordCollection $records = null;
 
     private function __construct(
         ?string $template,
@@ -21,7 +21,7 @@ final class DomainZone implements DomainObjectInterface
         int $expire,
         int $ttl,
         array $defaultRecords,
-        array $records
+        ?array $records
     ) {
         $this->template = $template;
         $this->hostMaster = $hostMaster;
@@ -30,7 +30,9 @@ final class DomainZone implements DomainObjectInterface
         $this->expire = $expire;
         $this->ttl = $ttl;
         $this->defaultRecords = DomainZoneRecordCollection::fromArray($defaultRecords);
-        $this->records = DomainZoneRecordCollection::fromArray($records);
+        if ($records !== null) {
+            $this->records = DomainZoneRecordCollection::fromArray($records);
+        }
     }
 
     public static function fromArray(array $json): DomainZone
@@ -43,7 +45,7 @@ final class DomainZone implements DomainObjectInterface
             $json['expire'],
             $json['ttl'],
             $json['defaultRecords'],
-            $json['records'] ?? [],
+            $json['records'] ?? null,
         );
     }
 
@@ -57,7 +59,7 @@ final class DomainZone implements DomainObjectInterface
             'expire' => $this->expire,
             'ttl' => $this->ttl,
             'defaultRecords' => $this->defaultRecords->toArray(),
-            'records' => $this->records->toArray(),
+            'records' => ($this->records !== null ? $this->records->toArray() : null),
         ], static function ($x) {
             return $x !== null;
         });

--- a/src/Domain/DomainZoneRecord.php
+++ b/src/Domain/DomainZoneRecord.php
@@ -1,0 +1,54 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+use SandwaveIo\RealtimeRegister\Domain\Enum\DomainZoneRecordTypeEnum;
+
+final class DomainZoneRecord implements DomainObjectInterface
+{
+    public string $name;
+    public string $type;
+    public string $content;
+    public int $ttl;
+    public ?int $prio;
+
+    private function __construct(
+        string $name,
+        string $type,
+        string $content,
+        int $ttl,
+        ?int $prio
+    ) {
+        $this->name = $name;
+        $this->type = $type;
+        $this->content = $content;
+        $this->ttl = $ttl;
+        $this->prio = $prio;
+    }
+
+    public static function fromArray(array $json): DomainZoneRecord
+    {
+        DomainZoneRecordTypeEnum::validate($json['type']);
+
+        return new DomainZoneRecord(
+            $json['name'],
+            $json['type'],
+            $json['content'],
+            $json['ttl'],
+            $json['prio'] ?? null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'name' => $this->name,
+            'type' => $this->type,
+            'content' => $this->content,
+            'ttl' => $this->ttl,
+            'prio' => $this->prio,
+        ], static function ($x) {
+            return $x !== null;
+        });
+    }
+}

--- a/src/Domain/DomainZoneRecordCollection.php
+++ b/src/Domain/DomainZoneRecordCollection.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class DomainZoneRecordCollection extends AbstractCollection
+{
+    /** @var DomainZoneRecord[] */
+    public array $entities;
+
+    public static function fromArray(array $json): DomainZoneRecordCollection
+    {
+        return parent::fromArray($json);
+    }
+
+    public function offsetGet($offset): ?DomainZoneRecord
+    {
+        return $this->entities[$offset] ?? null;
+    }
+
+    public static function parseChild(array $json): DomainZoneRecord
+    {
+        return DomainZoneRecord::fromArray($json);
+    }
+}

--- a/src/Domain/Enum/DomainZoneRecordTypeEnum.php
+++ b/src/Domain/Enum/DomainZoneRecordTypeEnum.php
@@ -1,0 +1,46 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain\Enum;
+
+class DomainZoneRecordTypeEnum extends AbstractEnum
+{
+    public const TYPE_A = 'A';
+    public const TYPE_AAAA = 'AAAA';
+    public const TYPE_ALIAS = 'ALIAS';
+    public const TYPE_CAA = 'CAA';
+    public const TYPE_CNAME = 'CNAME';
+    public const TYPE_HINFO = 'HINFO';
+    public const TYPE_MBOXFW = 'MBOXFW';
+    public const TYPE_MX = 'MX';
+    public const TYPE_NAPTR = 'NAPTR';
+    public const TYPE_NS = 'NS';
+    public const TYPE_SOA = 'SOA';
+    public const TYPE_SRV = 'SRV';
+    public const TYPE_TXT = 'TXT';
+    public const TYPE_TLSA = 'TLSA';
+    public const TYPE_URL = 'URL';
+
+    protected static array $values = [
+        self::TYPE_A,
+        self::TYPE_AAAA,
+        self::TYPE_ALIAS,
+        self::TYPE_CAA,
+        self::TYPE_CNAME,
+        self::TYPE_HINFO,
+        self::TYPE_MBOXFW,
+        self::TYPE_MX,
+        self::TYPE_NAPTR,
+        self::TYPE_NS,
+        self::TYPE_SOA,
+        self::TYPE_SRV,
+        self::TYPE_TXT,
+        self::TYPE_TLSA,
+        self::TYPE_URL,
+    ];
+
+    /** @param string $value */
+    public static function validate($value): void
+    {
+        self::assertValueValid($value);
+    }
+}

--- a/tests/Clients/DomainsApiZoneTest.php
+++ b/tests/Clients/DomainsApiZoneTest.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\DomainZone;
+use SandwaveIo\RealtimeRegister\Domain\DomainZoneRecord;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class DomainsApiZoneTest extends TestCase
+{
+    public function test_zone(): void
+    {
+        $validDomainZoneDetails = include __DIR__ . '/../Domain/data/domain_zone_details.php';
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode($validDomainZoneDetails),
+            MockedClientFactory::assertRoute('GET', 'v2/domains/example.com/zone', $this)
+        );
+
+        $response = $sdk->domains->zone('example.com');
+
+        $this->assertInstanceOf(DomainZone::class, $response);
+        $this->assertSame($validDomainZoneDetails, $response->toArray());
+        $this->assertInstanceOf(DomainZoneRecord::class, $response->records[0]);
+    }
+}

--- a/tests/Clients/DomainsApiZoneUpdateTest.php
+++ b/tests/Clients/DomainsApiZoneUpdateTest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class DomainsApiZoneUpdateTest extends TestCase
+{
+    public function test_update(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('POST', 'v2/domains/example.com/zone/update', $this)
+        );
+
+        $sdk->domains->zoneUpdate(
+            'example.com',
+            'hostmaster@example.com',
+            3600,
+            3600,
+            1209600,
+            3600,
+            [],
+        );
+    }
+}

--- a/tests/Domain/data/domain_zone_details.php
+++ b/tests/Domain/data/domain_zone_details.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types = 1);
+
+return [
+    'hostMaster' => 'hostmaster@example.com',
+    'refresh' => 3600,
+    'retry' => 3600,
+    'expire' => 1209600,
+    'ttl' => 3600,
+    'defaultRecords' => [
+        [
+            'name' => 'example.com',
+            'type' => 'SOA',
+            'content' => 'ns1.yoursrs.com hostmaster@example.com 2022122300 3600 3600 1209600 3600',
+            'ttl' => 3600,
+        ],
+        [
+            'name' => 'example.com',
+            'type' => 'NS',
+            'content' => 'ns1.yoursrs.com',
+            'ttl' => 3600,
+        ],
+        [
+            'name' => 'example.com',
+            'type' => 'NS',
+            'content' => 'ns2.yoursrs.com',
+            'ttl' => 3600,
+        ],
+    ],
+    'records' => [
+        [
+            'name' => 'example.com',
+            'type' => 'A',
+            'content' => '1.1.1.1',
+            'ttl' => 3600,
+        ],
+        [
+            'name' => 'example.com',
+            'type' => 'AAAA',
+            'content' => '2606:4700:4700::1111',
+            'ttl' => 3600,
+        ],
+    ],
+];


### PR DESCRIPTION
Added support for [zoneinfo](https://dm.realtimeregister.com/docs/api/domains/zoneinfo) and [update](https://dm.realtimeregister.com/docs/api/domains/zoneupdate)

~~There is a bit of clutter in this pull request, since it also includes the changes in #64 (I forked it from that one)~~