### PR TITLE
Nameserver cannot be combined with Zone input

### DIFF
--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -75,7 +75,7 @@ final class DomainsApi extends AbstractApi
         ?string $authcode = null,
         ?string $languageCode = null,
         bool $autoRenew = true,
-        array $ns = [],
+        ?array $ns = null,
         ?bool $skipValidation = null,
         ?string $launchPhase = null,
         ?Zone $zone = null,
@@ -92,10 +92,13 @@ final class DomainsApi extends AbstractApi
             'authcode' => $authcode,
             'languageCode' => $languageCode,
             'autoRenew' => $autoRenew,
-            'ns' => $ns,
             'skipValidation' => $skipValidation,
             'launchPhase' => $launchPhase,
         ];
+
+        if (is_array($ns)) {
+            $payload['ns'] = $ns;
+        }
 
         if ($zone) {
             $payload['zone'] = $zone->toArray();


### PR DESCRIPTION
As per the [documentation](https://dm.realtimeregister.com/docs/api/domains/create), NS cannot be combined with a zone input (just like with the transfer or update call)

For that reason the $ns param should be optional.