### PR TITLE
Headers key insensitive

### DIFF
--- a/src/Api/CertificatesApi.php
+++ b/src/Api/CertificatesApi.php
@@ -176,7 +176,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates', $payload);
 
-        return (int) $response->headers()['X-Process-Id'][0];
+        return (int) $response->headers()['x-process-id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/renew */
@@ -247,7 +247,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/renew', $payload);
 
-        return (int) $response->headers()['X-Process-Id'][0];
+        return (int) $response->headers()['x-process-id'][0];
     }
 
     /** @see https://dm.realtimeregister.com/docs/api/ssl/reissue */
@@ -306,7 +306,7 @@ final class CertificatesApi extends AbstractApi
 
         $response = $this->client->post('/v2/ssl/certificates/' . $certificateId . '/reissue', $payload);
 
-        return (int) $response->headers()['X-Process-Id'][0];
+        return (int) $response->headers()['x-process-id'][0];
     }
 
     /* @see https://dm.realtimeregister.com/docs/api/ssl/revoke */

--- a/src/Support/RealtimeRegisterResponse.php
+++ b/src/Support/RealtimeRegisterResponse.php
@@ -23,7 +23,7 @@ class RealtimeRegisterResponse
 
     public static function fromString(string $response, array $headers): RealtimeRegisterResponse
     {
-        return new RealtimeRegisterResponse($response, $headers);
+        return new RealtimeRegisterResponse($response, array_change_key_case($headers));
     }
 
     public function json(): array

--- a/tests/AuthorizedClientTest.php
+++ b/tests/AuthorizedClientTest.php
@@ -128,7 +128,7 @@ class AuthorizedClientTest extends TestCase
             static fn (): Response => new Response(
                 202,
                 [
-                    'X-Process-Id' => 1,
+                    'x-process-id' => 1,
                     'Content-Type' => 'application/json',
                 ]
             )
@@ -137,9 +137,9 @@ class AuthorizedClientTest extends TestCase
         $response = $client->get('test');
 
         self::assertCount(2, $response->headers());
-        self::assertCount(1, $response->headers()['X-Process-Id']);
+        self::assertCount(1, $response->headers()['x-process-id']);
         self::assertCount(1, $response->headers()['Content-Type']);
-        self::assertSame(1, (int) $response->headers()['X-Process-Id'][0]);
+        self::assertSame(1, (int) $response->headers()['x-process-id'][0]);
         self::assertSame('application/json', $response->headers()['Content-Type'][0]);
     }
 }

--- a/tests/AuthorizedClientTest.php
+++ b/tests/AuthorizedClientTest.php
@@ -138,8 +138,8 @@ class AuthorizedClientTest extends TestCase
 
         self::assertCount(2, $response->headers());
         self::assertCount(1, $response->headers()['x-process-id']);
-        self::assertCount(1, $response->headers()['Content-Type']);
+        self::assertCount(1, $response->headers()['content-type']);
         self::assertSame(1, (int) $response->headers()['x-process-id'][0]);
-        self::assertSame('application/json', $response->headers()['Content-Type'][0]);
+        self::assertSame('application/json', $response->headers()['content-type'][0]);
     }
 }

--- a/tests/Clients/CertificatesApiRenewCertificateTest.php
+++ b/tests/Clients/CertificatesApiRenewCertificateTest.php
@@ -16,7 +16,7 @@ class CertificatesApiRenewCertificateTest extends TestCase
                 return new Response(
                     202,
                     [
-                        'X-Process-Id' => 1,
+                        'x-process-id' => 1,
                     ]
                 );
             },

--- a/tests/Clients/CertificatesApiRequestCertificateTest.php
+++ b/tests/Clients/CertificatesApiRequestCertificateTest.php
@@ -16,7 +16,7 @@ class CertificatesApiRequestCertificateTest extends TestCase
                 return new Response(
                     202,
                     [
-                        'X-Process-Id' => 1,
+                        'x-process-id' => 1,
                     ],
                     json_encode([
                         'commonName' => 'commonname.com',


### PR DESCRIPTION
Fixes the issue where `X-Process-Id` sometimes was send as lowercase. Now it defaults it to lowercase.

`tests/Clients/CertificatesApiReissueCertificateTest.php` tests the existing `X-Process-Id`.