### PR TITLE
Make zone properties public

### DIFF
--- a/src/Domain/Zone.php
+++ b/src/Domain/Zone.php
@@ -6,7 +6,7 @@ use SandwaveIo\RealtimeRegister\Domain\Enum\DomainZoneServiceEnum;
 
 final class Zone implements DomainObjectInterface
 {
-    private function __construct(private string $service, private ?string $template, private ?bool $link)
+    private function __construct(public string $service, public ?string $template, public ?bool $link)
     {
     }
 

--- a/src/Domain/Zone.php
+++ b/src/Domain/Zone.php
@@ -6,7 +6,7 @@ use SandwaveIo\RealtimeRegister\Domain\Enum\DomainZoneServiceEnum;
 
 final class Zone implements DomainObjectInterface
 {
-    private function __construct(public string $service, public ?string $template, public ?bool $link)
+    private function __construct(public readonly string $service, public ?string $template, public ?bool $link)
     {
     }
 


### PR DESCRIPTION
The only way to access the properties is to call `toArray` on the object.

I also made the service read only because this is validated so it should not change on the object.