### PR TITLE
[IsProxy] Add the ability to enable functions that return extra data

### DIFF
--- a/src/Domain/IsProxyDomain.php
+++ b/src/Domain/IsProxyDomain.php
@@ -4,19 +4,22 @@ namespace SandwaveIo\RealtimeRegister\Domain;
 
 final class IsProxyDomain
 {
-    const STATUS_ERROR          = 'error';
-    const STATUS_AVAILABLE      = 'available';
-    const STATUS_NOT_AVAILABLE  = 'not available';
-    const STATUS_INVALID_DOMAIN = 'invalid domain';
+    public const STATUS_ERROR          = 'error';
+    public const STATUS_AVAILABLE      = 'available';
+    public const STATUS_NOT_AVAILABLE  = 'not available';
+    public const STATUS_INVALID_DOMAIN = 'invalid domain';
 
     private string $domain;
 
     private string $status;
 
-    public function __construct(string $domain, string $status)
+    private array $extras;
+
+    public function __construct(string $domain, string $status, array $extras = [])
     {
         $this->domain = $domain;
         $this->status = $status;
+        $this->extras = $extras;
     }
 
     public function getDomain(): string
@@ -27,6 +30,11 @@ final class IsProxyDomain
     public function getStatus(): string
     {
         return $this->status;
+    }
+
+    public function getExtras(): array
+    {
+        return $this->extras;
     }
 
     public function isAvailable(): bool

--- a/src/IsProxy.php
+++ b/src/IsProxy.php
@@ -55,7 +55,7 @@ final class IsProxy
 
     public function enable(string $function): bool
     {
-        if (!$this->connection->isConnected() && !$this->connection->connect()) {
+        if (! $this->connection->isConnected() && ! $this->connection->connect()) {
             throw new IsProxyConnectionException('Cannot connect to IsProxy');
         }
 

--- a/src/Support/IsProxyConnection.php
+++ b/src/Support/IsProxyConnection.php
@@ -66,6 +66,11 @@ class IsProxyConnection
         return trim($response);
     }
 
+    public function isConnected(): bool
+    {
+        return is_resource($this->socket);
+    }
+
     protected function login(): bool
     {
         if (! $this->write('LOGIN ' . $this->apiKey)) {
@@ -78,10 +83,5 @@ class IsProxyConnection
         }
 
         return (bool) preg_match('#^100\sLogin\sok#', $response);
-    }
-
-    protected function isConnected(): bool
-    {
-        return is_resource($this->socket);
     }
 }

--- a/tests/Helpers/MockedIsProxyConnection.php
+++ b/tests/Helpers/MockedIsProxyConnection.php
@@ -16,6 +16,9 @@ class MockedIsProxyConnection extends IsProxyConnection
     /** @var string[] */
     private $expectedWrites;
 
+    /** @var bool */
+    private $connected = false;
+
     public function __construct(string $apiKey, TestCase $testCase)
     {
         parent::__construct($apiKey);
@@ -51,6 +54,7 @@ class MockedIsProxyConnection extends IsProxyConnection
 
     public function connect(): bool
     {
+        $this->connected = true;
         return $this->login();
     }
 
@@ -73,8 +77,8 @@ class MockedIsProxyConnection extends IsProxyConnection
         return $expected;
     }
 
-    protected function isConnected(): bool
+    public function isConnected(): bool
     {
-        return true;
+        return $this->connected;
     }
 }

--- a/tests/IsProxyConnectionTest.php
+++ b/tests/IsProxyConnectionTest.php
@@ -119,4 +119,68 @@ class IsProxyConnectionTest extends TestCase
         $this->expectException(IsProxyConnectionException::class);
         $isProxy->checkMany('example', ['com', 'nl', 'net', 'org', 'fail']);
     }
+
+    public function test_check_premium(): void
+    {
+        $connection = (new MockedIsProxyConnection('secret', $this))
+            ->expectWrite('LOGIN secret')
+            ->expectRead('100 Login ok')
+            ->expectWrite('ENABLE premium')
+            ->expectRead('100 ok')
+            ->expectWrite('IS example.com')
+            ->expectRead('example.com available (type=premium,price=1500,currency=USD)')
+            ->expectWrite('IS example.de')
+            ->expectRead('example.de available')
+            ->expectWrite('IS example.nl')
+            ->expectRead('example.nl not available')
+            ->expectWrite('IS example.net')
+            ->expectRead('example.net error')
+            ->expectWrite('IS example.org')
+            ->expectRead('example.org invalid domain')
+            ->expectWrite('IS example.fail')
+            ->expectRead('lkjsdflkjsdf')
+            ->expectWrite('CLOSE');
+
+        $isProxy = new IsProxy('secret');
+        $isProxy->setConnection($connection);
+        $isProxy->enable('premium');
+
+        $result = $isProxy->checkMany('example', ['com', 'de', 'nl', 'net', 'org', 'fail']);
+
+        $this->assertCount(5, $result, 'Unexpected number of results');
+
+        [$premiumDomain, $availableDomain, $notAvailableDomain, $errorDomain, $invalidDomain] = $result;
+
+        $this->assertInstanceOf(IsProxyDomain::class, $premiumDomain);
+        $this->assertSame(IsProxyDomain::STATUS_AVAILABLE, $premiumDomain->getStatus());
+        $this->assertSame('example.com', $premiumDomain->getDomain());
+        $this->assertEquals(['type' => 'premium', 'price' => '1500', 'currency' => 'USD'], $premiumDomain->getExtras());
+        $this->assertSame('example.com', $premiumDomain->getDomain());
+        $this->assertTrue($premiumDomain->isAvailable());
+
+        $this->assertInstanceOf(IsProxyDomain::class, $availableDomain);
+        $this->assertSame(IsProxyDomain::STATUS_AVAILABLE, $availableDomain->getStatus());
+        $this->assertSame('example.de', $availableDomain->getDomain());
+        $this->assertEmpty($availableDomain->getExtras());
+        $this->assertTrue($availableDomain->isAvailable());
+
+        $this->assertInstanceOf(IsProxyDomain::class, $notAvailableDomain);
+        $this->assertSame(IsProxyDomain::STATUS_NOT_AVAILABLE, $notAvailableDomain->getStatus());
+        $this->assertSame('example.nl', $notAvailableDomain->getDomain());
+        $this->assertEmpty($availableDomain->getExtras());
+        $this->assertTrue($notAvailableDomain->isNotAvailable());
+
+        $this->assertInstanceOf(IsProxyDomain::class, $errorDomain);
+        $this->assertSame(IsProxyDomain::STATUS_ERROR, $errorDomain->getStatus());
+        $this->assertSame('example.net', $errorDomain->getDomain());
+        $this->assertEmpty($availableDomain->getExtras());
+        $this->assertTrue($errorDomain->isError());
+
+        $this->assertInstanceOf(IsProxyDomain::class, $invalidDomain);
+        $this->assertSame(IsProxyDomain::STATUS_INVALID_DOMAIN, $invalidDomain->getStatus());
+        $this->assertSame('example.org', $invalidDomain->getDomain());
+        $this->assertEmpty($availableDomain->getExtras());
+        $this->assertTrue($invalidDomain->isInvalid());
+    }
+
 }

--- a/tests/IsProxyConnectionTest.php
+++ b/tests/IsProxyConnectionTest.php
@@ -154,7 +154,7 @@ class IsProxyConnectionTest extends TestCase
         $this->assertInstanceOf(IsProxyDomain::class, $premiumDomain);
         $this->assertSame(IsProxyDomain::STATUS_AVAILABLE, $premiumDomain->getStatus());
         $this->assertSame('example.com', $premiumDomain->getDomain());
-        $this->assertEquals(['type' => 'premium', 'price' => '1500', 'currency' => 'USD'], $premiumDomain->getExtras());
+        $this->assertSame(['type' => 'premium', 'price' => '1500', 'currency' => 'USD'], $premiumDomain->getExtras());
         $this->assertSame('example.com', $premiumDomain->getDomain());
         $this->assertTrue($premiumDomain->isAvailable());
 
@@ -182,5 +182,4 @@ class IsProxyConnectionTest extends TestCase
         $this->assertEmpty($availableDomain->getExtras());
         $this->assertTrue($invalidDomain->isInvalid());
     }
-
 }


### PR DESCRIPTION
Is Proxy allows us to enable functions for error reasons or premium pricings.

https://dm.realtimeregister.com/docs/api/isproxy

This implementation adds the extras to the IsProxyDomain object and adds the enable function to the IsProxy class