### PR TITLE
Add quote response to the appropriate methods

### DIFF
--- a/src/Domain/Billable.php
+++ b/src/Domain/Billable.php
@@ -6,40 +6,27 @@ use SandwaveIo\RealtimeRegister\Domain\Enum\BillableActionEnum;
 
 final class Billable implements DomainObjectInterface
 {
-    public string $product;
-
-    public string $action;
-
-    public int $quantity;
-
-    public ?int $amount;
-
-    public ?string $providerName;
-
-    private function __construct(
-        string $product,
-        string $action,
-        int $quantity,
-        ?int $amount,
-        ?string $providerName
+    public function __construct(
+        public readonly string $product,
+        public readonly BillableActionEnum $action,
+        public readonly int $quantity,
+        public readonly ?int $amount,
+        public readonly ?bool $refundable,
+        public readonly ?int $total,
+        public readonly ?string $providerName
     ) {
-        $this->product = $product;
-        $this->action = $action;
-        $this->quantity = $quantity;
-        $this->amount = $amount;
-        $this->providerName = $providerName;
     }
 
-    public static function fromArray(array $data): Billable
+    public static function fromArray(array $json): Billable
     {
-        BillableActionEnum::validate($data['action']);
-
         return new Billable(
-            $data['product'],
-            $data['action'],
-            $data['quantity'],
-            $data['amount'] ?? null,
-            $data['providerName'] ?? null
+            product: $json['product'],
+            action: BillableActionEnum::from($json['action']),
+            quantity: $json['quantity'],
+            amount: $json['amount'] ?? null,
+            refundable: $json['refundable'] ?? null,
+            total: $json['total'] ?? null,
+            providerName: $json['providerName'] ?? null
         );
     }
 
@@ -47,9 +34,11 @@ final class Billable implements DomainObjectInterface
     {
         return array_filter([
             'product' => $this->product,
-            'action' => $this->action,
+            'action' => $this->action->value,
             'quantity' => $this->quantity,
             'amount' => $this->amount,
+            'refundable' => $this->refundable,
+            'total' => $this->total,
             'providerName' => $this->providerName,
         ], function ($x) {
             return ! is_null($x);

--- a/src/Domain/DomainQuote.php
+++ b/src/Domain/DomainQuote.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class DomainQuote implements DomainObjectInterface
+{
+    public function __construct(
+        public readonly string $command,
+        public readonly Quote $quote,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'command' => $this->command,
+            'quote' => $this->quote->toArray(),
+        ];
+    }
+
+    public static function fromArray(array $json): DomainQuote
+    {
+        return new DomainQuote(
+            command: $json['command'],
+            quote: Quote::fromArray($json['quote'])
+        );
+    }
+}

--- a/src/Domain/Enum/BillableActionEnum.php
+++ b/src/Domain/Enum/BillableActionEnum.php
@@ -2,43 +2,20 @@
 
 namespace SandwaveIo\RealtimeRegister\Domain\Enum;
 
-class BillableActionEnum extends AbstractEnum
+enum BillableActionEnum: string
 {
-    const ACTION_CREATE = 'CREATE';
-    const ACTION_REQUEST = 'REQUEST';
-    const ACTION_TRANSFER = 'TRANSFER';
-    const ACTION_RENEW = 'RENEW';
-    const ACTION_RESTORE = 'RESTORE';
-    const ACTION_TRANSFER_RESTORE = 'TRANSFER_RESTORE';
-    const ACTION_UPDATE = 'UPDATE';
-    const ACTION_REGISTRANT_CHANGE = 'REGISTRANT_CHANGE';
-    const ACTION_LOCAL_CONTACT = 'LOCAL_CONTACT';
-    const ACTION_NEGATIVE_MARKUP = 'NEGATIVE_MARKUP';
-    const ACTION_PRIVACY_PROTECT = 'PRIVACY_PROTECT';
-    const ACTION_EXTRA_WILDCARD = 'EXTRA_WILDCARD';
-    const ACTION_EXTRA_DOMAIN = 'EXTRA_DOMAIN';
-    const ACTION_REGISTRY_LOCK = 'REGISTRY_LOCK';
-
-    protected static array $values = [
-        BillableActionEnum::ACTION_CREATE,
-        BillableActionEnum::ACTION_REQUEST,
-        BillableActionEnum::ACTION_TRANSFER,
-        BillableActionEnum::ACTION_RENEW,
-        BillableActionEnum::ACTION_RESTORE,
-        BillableActionEnum::ACTION_TRANSFER_RESTORE,
-        BillableActionEnum::ACTION_UPDATE,
-        BillableActionEnum::ACTION_REGISTRANT_CHANGE,
-        BillableActionEnum::ACTION_LOCAL_CONTACT,
-        BillableActionEnum::ACTION_NEGATIVE_MARKUP,
-        BillableActionEnum::ACTION_PRIVACY_PROTECT,
-        BillableActionEnum::ACTION_EXTRA_WILDCARD,
-        BillableActionEnum::ACTION_EXTRA_DOMAIN,
-        BillableActionEnum::ACTION_REGISTRY_LOCK,
-    ];
-
-    /** @param string $value */
-    public static function validate($value): void
-    {
-        BillableActionEnum::assertValueValid($value);
-    }
+    case ACTION_CREATE = 'CREATE';
+    case ACTION_REQUEST = 'REQUEST';
+    case ACTION_TRANSFER = 'TRANSFER';
+    case ACTION_RENEW = 'RENEW';
+    case ACTION_RESTORE = 'RESTORE';
+    case ACTION_TRANSFER_RESTORE = 'TRANSFER_RESTORE';
+    case ACTION_UPDATE = 'UPDATE';
+    case ACTION_REGISTRANT_CHANGE = 'REGISTRANT_CHANGE';
+    case ACTION_LOCAL_CONTACT = 'LOCAL_CONTACT';
+    case ACTION_NEGATIVE_MARKUP = 'NEGATIVE_MARKUP';
+    case ACTION_PRIVACY_PROTECT = 'PRIVACY_PROTECT';
+    case ACTION_EXTRA_WILDCARD = 'EXTRA_WILDCARD';
+    case ACTION_EXTRA_DOMAIN = 'EXTRA_DOMAIN';
+    case ACTION_REGISTRY_LOCK = 'REGISTRY_LOCK';
 }

--- a/src/Domain/Quote.php
+++ b/src/Domain/Quote.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class Quote implements DomainObjectInterface
+{
+    public function __construct(
+        public readonly string $currency,
+        public readonly int $total,
+        public readonly BillableCollection $billables
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'currency' => $this->currency,
+            'total' => $this->total,
+            'billables' => $this->billables->toArray(),
+        ];
+    }
+
+    public static function fromArray(array $json): Quote
+    {
+        return new Quote(
+            currency: $json['currency'],
+            total: $json['total'],
+            billables: BillableCollection::fromArray($json['billables'])
+        );
+    }
+}

--- a/tests/Clients/DomainsApiRegisterTest.php
+++ b/tests/Clients/DomainsApiRegisterTest.php
@@ -5,6 +5,7 @@ namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\BillableCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainContactCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainQuote;
 use SandwaveIo\RealtimeRegister\Domain\DomainRegistration;
 use SandwaveIo\RealtimeRegister\Domain\KeyDataCollection;
 use SandwaveIo\RealtimeRegister\Domain\Zone;
@@ -12,6 +13,24 @@ use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class DomainsApiRegisterTest extends TestCase
 {
+    public function test_register_quote(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/domain_registration_quote.php'),
+            MockedClientFactory::assertRoute('POST', 'v2/domains/example.nl', $this)
+        );
+
+        $registration = $sdk->domains->register(
+            domainName: 'example.nl',
+            customer: 'test',
+            registrant: 'John Doe',
+            isQuote: true
+        );
+
+        $this->assertInstanceOf(DomainQuote::class, $registration);
+    }
+
     public function test_register(): void
     {
         $sdk = MockedClientFactory::makeSdk(

--- a/tests/Clients/DomainsApiRenewTest.php
+++ b/tests/Clients/DomainsApiRenewTest.php
@@ -5,10 +5,34 @@ namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\BillableCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainQuote;
+use SandwaveIo\RealtimeRegister\Domain\Enum\BillableActionEnum;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class DomainsApiRenewTest extends TestCase
 {
+    public function test_renew_quote(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/domain_renew_quote.php'),
+            MockedClientFactory::assertRoute('POST', 'v2/domains/example.com/renew', $this)
+        );
+
+        $response = $sdk->domains->renew(
+            domain: 'example.com',
+            period: 12,
+            billables: BillableCollection::fromArray([
+                include __DIR__ . '/../Domain/data/billable_valid.php',
+                include __DIR__ . '/../Domain/data/billable_valid.php',
+            ]),
+            isQuote: true
+        );
+
+        $this->assertInstanceOf(DomainQuote::class, $response);
+        $this->assertSame(BillableActionEnum::ACTION_RENEW, $response->quote->billables[0]->action);
+    }
+
     public function test_renew(): void
     {
         $sdk = MockedClientFactory::makeSdk(

--- a/tests/Clients/DomainsApiRestoreTest.php
+++ b/tests/Clients/DomainsApiRestoreTest.php
@@ -5,10 +5,34 @@ namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 use DateTime;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\BillableCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainQuote;
+use SandwaveIo\RealtimeRegister\Domain\Enum\BillableActionEnum;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class DomainsApiRestoreTest extends TestCase
 {
+    public function test_restore_quote(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/domain_restore_quote.php'),
+            MockedClientFactory::assertRoute('POST', 'v2/domains/example.com/restore', $this)
+        );
+
+        $response = $sdk->domains->restore(
+            domain: 'example.com',
+            reason: 'just.. because!',
+            billables: BillableCollection::fromArray([
+                include __DIR__ . '/../Domain/data/billable_valid.php',
+                include __DIR__ . '/../Domain/data/billable_valid.php',
+            ]),
+            isQuote: true
+        );
+
+        $this->assertInstanceOf(DomainQuote::class, $response);
+        $this->assertSame(BillableActionEnum::ACTION_RESTORE, $response->quote->billables[0]->action);
+    }
+
     public function test_restore(): void
     {
         $sdk = MockedClientFactory::makeSdk(

--- a/tests/Clients/DomainsApiTransferTest.php
+++ b/tests/Clients/DomainsApiTransferTest.php
@@ -6,12 +6,44 @@ use JsonException;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\BillableCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainContactCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainQuote;
+use SandwaveIo\RealtimeRegister\Domain\Enum\BillableActionEnum;
 use SandwaveIo\RealtimeRegister\Domain\KeyDataCollection;
 use SandwaveIo\RealtimeRegister\Domain\Zone;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class DomainsApiTransferTest extends TestCase
 {
+    public function test_transfer_quote(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/domain_transfer_quote.php'),
+            MockedClientFactory::assertRoute('POST', 'v2/domains/example.com/transfer', $this)
+        );
+
+        $response = $sdk->domains->transfer(
+            domainName: 'example.com',
+            customer: 'test',
+            registrant: 'John Doe',
+            privacyProtect: false,
+            period: 12,
+            authcode: '123123123',
+            autoRenew: true,
+            ns: [],
+            transferContacts: 'test',
+            designatedAgent: 'OLD',
+            zone: Zone::fromArray(include __DIR__ . '/../Domain/data/zone_valid.php'),
+            contacts: DomainContactCollection::fromArray([include __DIR__ . '/../Domain/data/domain_contact_valid.php']),
+            keyData: KeyDataCollection::fromArray([include __DIR__ . '/../Domain/data/key_data_valid.php']),
+            billables: BillableCollection::fromArray([include __DIR__ . '/../Domain/data/billable_valid.php']),
+            isQuote: true,
+        );
+
+        $this->assertInstanceOf(DomainQuote::class, $response);
+        $this->assertSame(BillableActionEnum::ACTION_TRANSFER, $response->quote->billables[0]->action);
+    }
+
     /**
      * @throws JsonException
      */

--- a/tests/Clients/DomainsApiUpdateTest.php
+++ b/tests/Clients/DomainsApiUpdateTest.php
@@ -5,12 +5,44 @@ namespace SandwaveIo\RealtimeRegister\Tests\Clients;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\BillableCollection;
 use SandwaveIo\RealtimeRegister\Domain\DomainContactCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainQuote;
+use SandwaveIo\RealtimeRegister\Domain\Enum\BillableActionEnum;
 use SandwaveIo\RealtimeRegister\Domain\KeyDataCollection;
 use SandwaveIo\RealtimeRegister\Domain\Zone;
 use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
 
 class DomainsApiUpdateTest extends TestCase
 {
+    public function test_transfer_quote(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/domain_update_quote.php'),
+            MockedClientFactory::assertRoute('POST', 'v2/domains/example.com/update', $this)
+        );
+
+        $response = $sdk->domains->update(
+            domainName: 'example.com',
+            registrant: 'John Doe',
+            privacyProtect: false,
+            period: 12,
+            authcode: '123123123',
+            languageCode: 'nl',
+            autoRenew: true,
+            ns: [],
+            statuses: ['OK'],
+            designatedAgent: 'OLD',
+            zone: Zone::fromArray(include __DIR__ . '/../Domain/data/zone_valid.php'),
+            contacts: DomainContactCollection::fromArray([include __DIR__ . '/../Domain/data/contact_handle_valid.php']),
+            keyData: KeyDataCollection::fromArray([include __DIR__ . '/../Domain/data/key_data_valid.php']),
+            billables: BillableCollection::fromArray([include __DIR__ . '/../Domain/data/billable_valid.php']),
+            isQuote: true,
+        );
+
+        $this->assertInstanceOf(DomainQuote::class, $response);
+        $this->assertSame(BillableActionEnum::ACTION_UPDATE, $response->quote->billables[0]->action);
+    }
+
     public function test_update(): void
     {
         $sdk = MockedClientFactory::makeSdk(

--- a/tests/Domain/BillableObjectTest.php
+++ b/tests/Domain/BillableObjectTest.php
@@ -5,6 +5,7 @@ namespace SandwaveIo\RealtimeRegister\Tests\Domain;
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\Billable;
 use SandwaveIo\RealtimeRegister\Exceptions\InvalidArgumentException;
+use ValueError;
 
 /**
  * This TestCase is used to test all single Billable Objects.
@@ -32,7 +33,7 @@ class BillableObjectTest extends TestCase
             'invalid billable action' => [
                 Billable::class,
                 include __DIR__ . '/data/billable_invalid_action.php',
-                InvalidArgumentException::class,
+                ValueError::class,
             ],
         ];
     }

--- a/tests/Domain/BillableObjectTest.php
+++ b/tests/Domain/BillableObjectTest.php
@@ -4,7 +4,6 @@ namespace SandwaveIo\RealtimeRegister\Tests\Domain;
 
 use PHPUnit\Framework\TestCase;
 use SandwaveIo\RealtimeRegister\Domain\Billable;
-use SandwaveIo\RealtimeRegister\Exceptions\InvalidArgumentException;
 use ValueError;
 
 /**

--- a/tests/Domain/DomainObjectTest.php
+++ b/tests/Domain/DomainObjectTest.php
@@ -37,6 +37,7 @@ use SandwaveIo\RealtimeRegister\Domain\TLDInfo;
 use SandwaveIo\RealtimeRegister\Domain\Zone;
 use SandwaveIo\RealtimeRegister\Exceptions\InvalidArgumentException;
 use TypeError;
+use ValueError;
 
 /**
  * This TestCase is used to test all single Domain Objects.
@@ -69,7 +70,7 @@ class DomainObjectTest extends TestCase
             'invalid billable (action)' => [
                 Billable::class,
                 include __DIR__ . '/data/billable_invalid_action.php',
-                InvalidArgumentException::class,
+                ValueError::class,
             ],
             'valid contact (all fields)' => [
                 Contact::class,

--- a/tests/Domain/data/domain_registration_quote.php
+++ b/tests/Domain/data/domain_registration_quote.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+return [
+    'command' => 'CreateDomainCommand',
+    'quote' => [
+        'currency' => 'EUR',
+        'billables' => [
+            [
+                'action' => 'CREATE',
+                'product' => 'domain_com',
+                'quantity' => 1,
+                'amount' => 500,
+                'refundable' => true,
+                'total' => 500,
+            ],
+        ],
+        'total' => 500,
+    ],
+];

--- a/tests/Domain/data/domain_renew_quote.php
+++ b/tests/Domain/data/domain_renew_quote.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+return [
+    'command' => 'RenewDomainCommand',
+    'quote' => [
+        'currency' => 'EUR',
+        'billables' => [
+            [
+                'action' => 'RENEW',
+                'product' => 'domain_com',
+                'quantity' => 1,
+                'amount' => 500,
+                'refundable' => true,
+                'total' => 500,
+            ],
+        ],
+        'total' => 500,
+    ],
+];

--- a/tests/Domain/data/domain_restore_quote.php
+++ b/tests/Domain/data/domain_restore_quote.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+return [
+    'command' => 'RestoreDomainCommand',
+    'quote' => [
+        'currency' => 'EUR',
+        'billables' => [
+            [
+                'action' => 'RESTORE',
+                'product' => 'domain_com',
+                'quantity' => 1,
+                'amount' => 500,
+                'refundable' => false,
+                'total' => 500,
+            ],
+        ],
+        'total' => 500,
+    ],
+];

--- a/tests/Domain/data/domain_transfer_quote.php
+++ b/tests/Domain/data/domain_transfer_quote.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+return [
+    'command' => 'TransferDomainCommand',
+    'quote' => [
+        'currency' => 'EUR',
+        'billables' => [
+            [
+                'action' => 'TRANSFER',
+                'product' => 'domain_com',
+                'quantity' => 1,
+                'amount' => 500,
+                'refundable' => false,
+                'total' => 500,
+            ],
+        ],
+        'total' => 500,
+    ],
+];

--- a/tests/Domain/data/domain_update_quote.php
+++ b/tests/Domain/data/domain_update_quote.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+return [
+    'command' => 'UpdateDomainCommand',
+    'quote' => [
+        'currency' => 'EUR',
+        'billables' => [
+            [
+                'action' => 'UPDATE',
+                'product' => 'domain_com',
+                'quantity' => 1,
+                'amount' => 500,
+                'refundable' => false,
+                'total' => 500,
+            ],
+        ],
+        'total' => 500,
+    ],
+];


### PR DESCRIPTION
https://dm.realtimeregister.com/docs/api/quotes

Added the quote responses to the domain methods.

Also make use of php enums instead of custom ones.
This could be reverted to use the internal enums but i thinks we should move them all to the new php enums.

Another thing i changed/added is making use of readonly properties and a public constructor.
This way an object in immutable and can safely be created with named arguments.