### PR TITLE
Added DNS zone management options

### DIFF
--- a/src/Api/DnsZonesApi.php
+++ b/src/Api/DnsZonesApi.php
@@ -1,0 +1,225 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Api;
+
+use InvalidArgumentException;
+use SandwaveIo\RealtimeRegister\Domain\DnsZone;
+use SandwaveIo\RealtimeRegister\Domain\DnsZoneCollection;
+use SandwaveIo\RealtimeRegister\Domain\DomainZoneRecordCollection;
+use SandwaveIo\RealtimeRegister\Domain\Enum\ZoneServiceEnum;
+use Webmozart\Assert\Assert;
+
+final class DnsZonesApi extends AbstractApi
+{
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/dns/zones/list
+     *
+     * @param int|null    $limit
+     * @param int|null    $offset
+     * @param string|null $search
+     * @param array|null  $parameters
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return DnsZoneCollection
+     */
+    public function list(
+        ?int $limit = null,
+        ?int $offset = null,
+        ?string $search = null,
+        ?array $parameters = null
+    ): DnsZoneCollection {
+        $query = [];
+        if ($limit !== null) {
+            $query['limit'] = $limit;
+        }
+        if ($offset !== null) {
+            $query['offset'] = $offset;
+        }
+        if ($search !== null) {
+            $query['q'] = $search;
+        }
+        if ($parameters !== null) {
+            $query = array_merge($parameters, $query);
+        }
+
+        $response = $this->client->get('v2/dns/zones', $query);
+        return DnsZoneCollection::fromArray($response->json());
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/dns/zones/get
+     *
+     * @param int $id
+     *
+     * @throws InvalidArgumentException
+     *
+     * @return DnsZone
+     */
+    public function get(int $id): DnsZone
+    {
+        $response = $this->client->get(
+            sprintf('v2/dns/zones/%s', $id)
+        );
+        return DnsZone::fromArray($response->json());
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/dns/zones/create
+     *
+     * @throws InvalidArgumentException
+     */
+    public function create(
+        string $name,
+        ?ZoneServiceEnum $service = null,
+        ?string $template = null,
+        ?bool $link = null,
+        ?string $master = null,
+        ?array $ns = null,
+        ?bool $dnssec = null,
+        ?string $hostMaster = null,
+        ?int $refresh = null,
+        ?int $retry = null,
+        ?int $expire = null,
+        ?int $ttl = null,
+        ?DomainZoneRecordCollection $records = null,
+    ): void {
+        $this->validateZoneName($name);
+
+        $payload = [
+            'name' => $name,
+        ];
+        if ($service !== null) {
+            $payload['service'] = $service->value;
+        }
+        if ($template !== null) {
+            $payload['template'] = $template;
+        }
+        if ($link !== null) {
+            $payload['link'] = $link;
+        }
+        if ($master !== null) {
+            $payload['master'] = $master;
+        }
+        if($ns !== null) {
+            $payload['ns'] = $ns;
+        }
+        if($dnssec !== null) {
+            $payload['dnssec'] = $dnssec;
+        }
+        if($hostMaster !== null) {
+            $payload['hostMaster'] = $hostMaster;
+        }
+        if($refresh !== null) {
+            $payload['refresh'] = $refresh;
+        }
+        if($retry !== null) {
+            $payload['retry'] = $retry;
+        }
+        if($expire !== null) {
+            $payload['expire'] = $expire;
+        }
+        if($ttl !== null) {
+            $payload['ttl'] = $ttl;
+        }
+        if($records !== null) {
+            $payload['records'] = $records->toArray();
+        }
+
+        $this->client->post('v2/dns/zones', $payload);
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/dns/zones/update
+     *
+     * @throws InvalidArgumentException
+     */
+    public function update(
+        int $id,
+        ?string $name,
+        ?ZoneServiceEnum $service = null,
+        ?string $template = null,
+        ?bool $link = null,
+        ?string $master = null,
+        ?array $ns = null,
+        ?bool $dnssec = null,
+        ?string $hostMaster = null,
+        ?int $refresh = null,
+        ?int $retry = null,
+        ?int $expire = null,
+        ?int $ttl = null,
+        ?DomainZoneRecordCollection $records = null,
+    ): void {
+        $payload = [];
+        if ($name !== null) {
+            $this->validateZoneName($name);
+            $payload['name'] = $name;
+        }
+        if ($service !== null) {
+            $payload['service'] = $service->value;
+        }
+        if ($template !== null) {
+            $payload['template'] = $template;
+        }
+        if ($link !== null) {
+            $payload['link'] = $link;
+        }
+        if ($master !== null) {
+            $payload['master'] = $master;
+        }
+        if($ns !== null) {
+            $payload['ns'] = $ns;
+        }
+        if($dnssec !== null) {
+            $payload['dnssec'] = $dnssec;
+        }
+        if($hostMaster !== null) {
+            $payload['hostMaster'] = $hostMaster;
+        }
+        if($refresh !== null) {
+            $payload['refresh'] = $refresh;
+        }
+        if($retry !== null) {
+            $payload['retry'] = $retry;
+        }
+        if($expire !== null) {
+            $payload['expire'] = $expire;
+        }
+        if($ttl !== null) {
+            $payload['ttl'] = $ttl;
+        }
+        if($records !== null) {
+            $payload['records'] = $records->toArray();
+        }
+
+        $this->client->post(
+            sprintf('v2/dns/zones/%s/update', $id),
+            $payload,
+        );
+    }
+
+    /**
+     * @see https://dm.realtimeregister.com/docs/api/dns/zones/delete
+     *
+     * @param int $id The id of the zone to delete
+     */
+    public function delete(int $id): void
+    {
+        $this->client->delete(
+            sprintf('v2/dns/zones/%s', $id)
+        );
+    }
+
+    /**
+     * Validate zone name input.
+     *
+     * @param string $name Zone name
+     *
+     * @throws InvalidArgumentException
+     */
+    private function validateZoneName(string $name): void
+    {
+        Assert::lengthBetween($name, 3, 40, 'Zone name should be between 3 and 40 characters');
+        Assert::regex($name, '/^[a-zA-Z0-9\-_@.]+$/', 'Invalid zone name, allowed characters: a-z A-Z 0-9 - _ @ .');
+    }
+}

--- a/src/Domain/DnsZone.php
+++ b/src/Domain/DnsZone.php
@@ -1,0 +1,87 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+use DateTimeImmutable;
+use SandwaveIo\RealtimeRegister\Domain\Enum\ZoneServiceEnum;
+
+final class DnsZone implements DomainObjectInterface
+{
+    private function __construct(
+        public int $id,
+        public string $name,
+        public string $customer,
+        public DateTimeImmutable $createdDate,
+        public ?DateTimeImmutable $updatedDate,
+        public ?DateTimeImmutable $deletionDate,
+        public bool $managed,
+        public ZoneServiceEnum $service,
+        public ?string $template,
+        public ?string $master,
+        public ?array $ns,
+        public DomainZoneRecordCollection $defaultRecords,
+        public string $hostMaster = 'hostmaster@realtimeregister.com',
+        public int $refresh = 3600,
+        public int $retry = 3600,
+        public int $expire = 14 * 24 * 60 * 60,
+        public int $ttl = 3600,
+        public bool $dnssec = false,
+        public ?DomainZoneRecordCollection $records = null,
+        public ?KeyDataCollection $keyData = null,
+    ) {
+    }
+
+    public static function fromArray(array $json): self
+    {
+        return new DnsZone(
+            $json['id'],
+            $json['name'] ?? null,
+            $json['customer'],
+            new DateTimeImmutable($json['createdDate']),
+            isset($json['updatedDate']) ? new DateTimeImmutable($json['updatedDate']) : null,
+            isset($json['deletionDate']) ? new DateTimeImmutable($json['deletionDate']) : null,
+            $json['managed'],
+            ZoneServiceEnum::from($json['service']),
+            $json['template'] ?? null,
+            $json['master'] ?? null,
+            $json['ns'] ?? null,
+            DomainZoneRecordCollection::fromArray($json['defaultRecords']),
+            $json['hostMaster'],
+            $json['refresh'],
+            $json['retry'],
+            $json['expire'],
+            $json['ttl'],
+            $json['dnssec'],
+            isset($json['records']) ? DomainZoneRecordCollection::fromArray($json['records']) : null,
+            isset($json['keyData']) ? KeyDataCollection::fromArray($json['keyData']) : null,
+        );
+    }
+
+    public function toArray(): array
+    {
+        return array_filter([
+            'id' => $this->id,
+            'customer' => $this->customer,
+            'name' => $this->name,
+            'createdDate' => $this->createdDate->format('Y-m-d\TH:i:s\Z'),
+            'updatedDate' => $this->updatedDate?->format('Y-m-d\TH:i:s\Z'),
+            'deletionDate' => $this->deletionDate?->format('Y-m-d\TH:i:s\Z'),
+            'service' => $this->service->value,
+            'dnssec' => $this->dnssec,
+            'managed' => $this->managed,
+            'template' => $this->template,
+            'master' => $this->master,
+            'ns' => $this->ns,
+            'hostMaster' => $this->hostMaster,
+            'refresh' => $this->refresh,
+            'retry' => $this->retry,
+            'expire' => $this->expire,
+            'ttl' => $this->ttl,
+            'defaultRecords' => $this->defaultRecords->toArray(),
+            'records' => $this->records?->toArray(),
+            'keyData' => $this->keyData?->toArray(),
+        ], function ($x) {
+            return $x !== null;
+        });
+    }
+}

--- a/src/Domain/DnsZoneCollection.php
+++ b/src/Domain/DnsZoneCollection.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain;
+
+final class DnsZoneCollection extends AbstractCollection
+{
+    /** @var DnsZone[] */
+    public array $entities;
+
+    public static function fromArray(array $json): self
+    {
+        return parent::fromArray($json);
+    }
+
+    public function offsetGet($offset): ?DnsZone
+    {
+        return $this->entities[$offset] ?? null;
+    }
+
+    public static function parseChild(array $json): DnsZone
+    {
+        return DnsZone::fromArray($json);
+    }
+}

--- a/src/Domain/Enum/ZoneServiceEnum.php
+++ b/src/Domain/Enum/ZoneServiceEnum.php
@@ -1,0 +1,9 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Domain\Enum;
+
+enum ZoneServiceEnum: string
+{
+    case BASIC = 'BASIC';
+    case PREMIUM = 'PREMIUM';
+}

--- a/src/IsProxy.php
+++ b/src/IsProxy.php
@@ -76,7 +76,7 @@ final class IsProxy
             return null;
         }
 
-        if (! $matches['extra']) {
+        if (! isset($matches['extra'])) {
             return new IsProxyDomain($matches['domain'], $matches['status']);
         }
 

--- a/src/RealtimeRegister.php
+++ b/src/RealtimeRegister.php
@@ -8,6 +8,7 @@ use SandwaveIo\RealtimeRegister\Api\CertificatesApi;
 use SandwaveIo\RealtimeRegister\Api\ContactsApi;
 use SandwaveIo\RealtimeRegister\Api\CustomersApi;
 use SandwaveIo\RealtimeRegister\Api\DnsTemplatesApi;
+use SandwaveIo\RealtimeRegister\Api\DnsZonesApi;
 use SandwaveIo\RealtimeRegister\Api\DomainsApi;
 use SandwaveIo\RealtimeRegister\Api\FinancialApi;
 use SandwaveIo\RealtimeRegister\Api\NotificationsApi;
@@ -38,6 +39,8 @@ final class RealtimeRegister
 
     public DnsTemplatesApi $dnstemplates;
 
+    public DnsZonesApi $dnszones;
+
     public TLDsApi $tlds;
 
     public FinancialApi $financial;
@@ -62,6 +65,7 @@ final class RealtimeRegister
         $this->processes = new ProcessesApi($client);
         $this->providers = new ProvidersApi($client);
         $this->dnstemplates = new DnsTemplatesApi($client);
+        $this->dnszones = new DnsZonesApi($client);
         $this->tlds = new TLDsApi($client);
         $this->financial = new FinancialApi($client);
     }

--- a/tests/Clients/DnsZonesApiCreateTest.php
+++ b/tests/Clients/DnsZonesApiCreateTest.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\DomainZoneRecordCollection;
+use SandwaveIo\RealtimeRegister\Domain\Enum\ZoneServiceEnum;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class DnsZonesApiCreateTest extends TestCase
+{
+    public function test_create(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('POST', 'v2/dns/zones', $this)
+        );
+
+        $sdk->dnszones->create(
+            'test',
+            ZoneServiceEnum::BASIC,
+            'magazine',
+            false,
+        );
+    }
+
+    public function test_create_with_records(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('POST', 'v2/dns/zones', $this)
+        );
+
+        $sdk->dnszones->create(
+            'test',
+            ZoneServiceEnum::BASIC,
+            'magazine',
+            false,
+            'master',
+            ['ns1.donaldduck.nl', 'ns2.donaldduck.nl'],
+            false,
+            'movies@ducktown.disney.com',
+            129371293,
+            123456,
+            78123139,
+            712312377,
+            DomainZoneRecordCollection::fromArray(
+                [
+                    [
+                        'name' => '##DOMAIN##',
+                        'type' => 'URL',
+                        'content' => 'http://www.donaldduck.nl/',
+                        'ttl' => 300,
+                    ],
+                    [
+                        'name' => 'www.##DOMAIN##',
+                        'type' => 'A',
+                        'content' => '1.1.1.1',
+                        'ttl' => 300,
+                    ],
+                ]
+            )
+        );
+    }
+
+    public function test_create_invalid(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            ''
+        );
+        $this->expectException('Webmozart\Assert\InvalidArgumentException');
+        $sdk->dnszones->create(
+            'this is not possible',
+            ZoneServiceEnum::PREMIUM,
+        );
+    }
+}

--- a/tests/Clients/DnsZonesApiDeleteTest.php
+++ b/tests/Clients/DnsZonesApiDeleteTest.php
@@ -1,0 +1,19 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class DnsZonesApiDeleteTest extends TestCase
+{
+    public function test_delete(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('DELETE', 'v2/dns/zones/1111111111', $this)
+        );
+        $sdk->dnszones->delete(1111111111);
+    }
+}

--- a/tests/Clients/DnsZonesApiGetTest.php
+++ b/tests/Clients/DnsZonesApiGetTest.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class DnsZonesApiGetTest extends TestCase
+{
+    public function test_get(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode(include __DIR__ . '/../Domain/data/dnszone_valid_with_records.php'),
+            MockedClientFactory::assertRoute('GET', 'v2/dns/zones/1111111111', $this)
+        );
+
+        $response = $sdk->dnszones->get(1111111111);
+        $this->assertSame(2, $response->records->count());
+    }
+}

--- a/tests/Clients/DnsZonesApiListTest.php
+++ b/tests/Clients/DnsZonesApiListTest.php
@@ -1,0 +1,92 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class DnsZonesApiListTest extends TestCase
+{
+    public function test_list(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/dnszone_valid_with_records.php',
+                    include __DIR__ . '/../Domain/data/dnszone_valid_without_records.php',
+                    include __DIR__ . '/../Domain/data/dnszone_valid_with_records.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 10,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/dns/zones', $this)
+        );
+
+        $response = $sdk->dnszones->list();
+        $this->assertSame(3, $response->count());
+    }
+
+    public function test_list_with_queries(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/dnszone_valid_with_records.php',
+                    include __DIR__ . '/../Domain/data/dnszone_valid_without_records.php',
+                    include __DIR__ . '/../Domain/data/dnszone_valid_with_records.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute(
+                'GET',
+                'v2/dns/zones',
+                $this,
+                ['limit'=>'3', 'offset'=>'0', 'q'=>'john']
+            )
+        );
+
+        $response = $sdk->dnszones->list(3, 0, 'john');
+        $this->assertSame(3, $response->count());
+    }
+
+    public function test_list_with_search_and_parameters(): void
+    {
+        $parameters = [
+            'name' => 'test',
+        ];
+
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            json_encode([
+                'entities' => [
+                    include __DIR__ . '/../Domain/data/dnszone_valid_with_records.php',
+                    include __DIR__ . '/../Domain/data/dnszone_valid_without_records.php',
+                    include __DIR__ . '/../Domain/data/dnszone_valid_with_records.php',
+                ],
+                'pagination' => [
+                    'total'  => 3,
+                    'offset' => 0,
+                    'limit'  => 3,
+                ],
+            ]),
+            MockedClientFactory::assertRoute('GET', 'v2/dns/zones', $this, [
+                'name' => 'test',
+                'limit' => '3',
+                'offset' => '0',
+                'q' => 'john',
+            ])
+        );
+
+        $response = $sdk->dnszones->list(3, 0, 'john', $parameters);
+        $this->assertSame(3, $response->count());
+    }
+}

--- a/tests/Clients/DnsZonesApiUpdateTest.php
+++ b/tests/Clients/DnsZonesApiUpdateTest.php
@@ -1,0 +1,83 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Clients;
+
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\DomainZoneRecordCollection;
+use SandwaveIo\RealtimeRegister\Domain\Enum\ZoneServiceEnum;
+use SandwaveIo\RealtimeRegister\Tests\Helpers\MockedClientFactory;
+
+class DnsZonesApiUpdateTest extends TestCase
+{
+    public function test_update(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('POST', 'v2/dns/zones/1111111111/update', $this)
+        );
+
+        $sdk->dnszones->update(
+            1111111111,
+            'test',
+            ZoneServiceEnum::BASIC,
+            'magazine',
+            false,
+        );
+    }
+
+    public function test_update_with_records(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            '',
+            MockedClientFactory::assertRoute('POST', 'v2/dns/zones/1111111111/update', $this)
+        );
+
+        $sdk->dnszones->update(
+            1111111111,
+            'test',
+            ZoneServiceEnum::BASIC,
+            'magazine',
+            false,
+            'master',
+            ['ns1.donaldduck.nl', 'ns2.donaldduck.nl'],
+            false,
+            'movies@ducktown.disney.com',
+            129371293,
+            123456,
+            78123139,
+            712312377,
+            DomainZoneRecordCollection::fromArray(
+                [
+                    [
+                        'name' => '##DOMAIN##',
+                        'type' => 'URL',
+                        'content' => 'http://www.donaldduck.nl/',
+                        'ttl' => 300,
+                    ],
+                    [
+                        'name' => 'www.##DOMAIN##',
+                        'type' => 'A',
+                        'content' => '1.1.1.1',
+                        'ttl' => 300,
+                    ],
+                ]
+            )
+        );
+    }
+
+    public function test_update_invalid(): void
+    {
+        $sdk = MockedClientFactory::makeSdk(
+            200,
+            ''
+        );
+        $this->expectException('Webmozart\Assert\InvalidArgumentException');
+        $sdk->dnszones->update(
+            1111111111,
+            'this is not possible',
+            ZoneServiceEnum::PREMIUM,
+        );
+    }
+}

--- a/tests/Domain/DnsZoneCollectionTest.php
+++ b/tests/Domain/DnsZoneCollectionTest.php
@@ -1,0 +1,74 @@
+<?php declare(strict_types = 1);
+
+namespace SandwaveIo\RealtimeRegister\Tests\Domain;
+
+use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\TestCase;
+use SandwaveIo\RealtimeRegister\Domain\DnsZone;
+use SandwaveIo\RealtimeRegister\Domain\DnsZoneCollection;
+
+final class DnsZoneCollectionTest extends TestCase
+{
+    public function test_from_array(): void
+    {
+        $dnsZoneCollectionData = include __DIR__ . '/data/dnszonecollection_valid.php';
+
+        $dnsZoneCollection = DnsZoneCollection::fromArray($dnsZoneCollectionData);
+
+        Assert::assertCount(2, $dnsZoneCollection);
+
+        $dnsTemplate = $dnsZoneCollection->offsetGet(1);
+
+        assert($dnsTemplate !== null);
+
+        Assert::assertInstanceOf(DnsZone::class, $dnsTemplate);
+        Assert::assertSame('john.doe@example.com', $dnsTemplate->hostMaster);
+    }
+
+    public function test_from_and_to_array(): void
+    {
+        $dnsZoneCollectionData = include __DIR__ . '/data/dnszonecollection_valid.php';
+
+        $dnsZoneCollection = DnsZoneCollection::fromArray($dnsZoneCollectionData);
+
+        Assert::assertSame($dnsZoneCollectionData, $dnsZoneCollection->toArray());
+    }
+
+    public function test_set_unset_exists(): void
+    {
+        $dnsZoneCollectionData = include __DIR__ . '/data/dnszonecollection_valid.php';
+
+        $dnsZoneCollection = DnsZoneCollection::fromArray($dnsZoneCollectionData);
+        $dnsZoneCollection->offsetSet(
+            '3',
+            DnsZone::fromArray([
+                'id'             => 333333,
+                'customer'       => 'coca',
+                'name'           => 'cola',
+                'hostMaster'     => 'drink@fresh.com',
+                'createdDate'    => '2024-02-08T14:40:00Z',
+                'service'        => 'BASIC',
+                'managed'        => false,
+                'dnssec'         => false,
+                'defaultRecords' => [],
+                'refresh'        => 123,
+                'retry'          => 456,
+                'expire'         => 789,
+                'ttl'            => 777,
+            ])
+        );
+
+        Assert::assertTrue($dnsZoneCollection->offsetExists(3));
+
+        $dnsTemplate = $dnsZoneCollection->offsetGet(3);
+
+        assert($dnsTemplate !== null);
+
+        Assert::assertSame('cola', $dnsTemplate->name);
+
+        $dnsZoneCollection->offsetUnset(3);
+
+        Assert::assertNull($dnsZoneCollection->offsetGet(3));
+        Assert::assertFalse($dnsZoneCollection->offsetExists(3));
+    }
+}

--- a/tests/Domain/data/dnszone_valid_with_records.php
+++ b/tests/Domain/data/dnszone_valid_with_records.php
@@ -1,0 +1,51 @@
+<?php declare(strict_types = 1);
+
+return [
+    'id'          => 1111111111,
+    'customer'    => 'donaldduck',
+    'name'        => 'magazine',
+    'createdDate' => '2023-05-08T05:10:20Z',
+    'service'     => 'PREMIUM',
+    'dnssec'      => false,
+    'managed'     => true,
+    'ns'          => ['ns1.yoursrs.com', 'ns2.yoursrs.com'],
+    'hostMaster'  => 'movies@ducktown.disney.com',
+    'refresh'     => 129371293,
+    'retry'       => 123456,
+    'expire'      => 78123139,
+    'ttl'         => 712312377,
+    'defaultRecords' => [
+        [
+            'name' => '##DOMAIN##',
+            'type' => 'NS',
+            'content' => 'ns2.yoursrs.com',
+            'ttl' => 3600,
+        ],
+        [
+            'name' => '##DOMAIN##',
+            'type' => 'NS',
+            'content' => 'ns1.yoursrs.com',
+            'ttl' => 3600,
+        ],
+        [
+            'name' => '##DOMAIN##',
+            'type' => 'SOA',
+            'content' => 'ns1.yoursrs.com dns.example.com 0 86400 10800 3600000 3600',
+            'ttl' => 3600,
+        ],
+    ],
+    'records'    => [
+        [
+            'name'    => '##DOMAIN##',
+            'type'    => 'URL',
+            'content' => 'http://www.donaldduck.nl/',
+            'ttl'     => 300,
+        ],
+        [
+            'name' => 'www.##DOMAIN##',
+            'type' => 'A',
+            'content' => '1.1.1.1',
+            'ttl' => 300,
+        ],
+    ],
+];

--- a/tests/Domain/data/dnszone_valid_without_records.php
+++ b/tests/Domain/data/dnszone_valid_without_records.php
@@ -1,0 +1,37 @@
+<?php declare(strict_types = 1);
+
+return [
+    'id'           => 1111111112,
+    'customer'     => 'johndoe',
+    'name'         => 'test',
+    'createdDate'  => '2023-05-08T05:10:20Z',
+    'service'      => 'PREMIUM',
+    'dnssec'       => false,
+    'managed'      => true,
+    'ns'           => ['ns1.yoursrs.com', 'ns2.yoursrs.com'],
+    'hostMaster'   => 'john.doe@example.com',
+    'refresh'      => 129371293,
+    'retry'        => 123456,
+    'expire'       => 78123139,
+    'ttl'          => 712312377,
+    'defaultRecords' => [
+        [
+            'name' => '##DOMAIN##',
+            'type' => 'NS',
+            'content' => 'ns2.yoursrs.com',
+            'ttl' => 3600,
+        ],
+        [
+            'name' => '##DOMAIN##',
+            'type' => 'NS',
+            'content' => 'ns1.yoursrs.com',
+            'ttl' => 3600,
+        ],
+        [
+            'name' => '##DOMAIN##',
+            'type' => 'SOA',
+            'content' => 'ns1.yoursrs.com dns.example.com 0 86400 10800 3600000 3600',
+            'ttl' => 3600,
+        ],
+    ],
+];

--- a/tests/Domain/data/dnszonecollection_valid.php
+++ b/tests/Domain/data/dnszonecollection_valid.php
@@ -1,0 +1,6 @@
+<?php declare(strict_types = 1);
+
+return [
+    include __DIR__ . '/dnszone_valid_with_records.php',
+    include __DIR__ . '/dnszone_valid_without_records.php',
+];


### PR DESCRIPTION
Noticed these were missing since the introduction of the new DNS Zone management API.

I've reused the DomainZoneRecordCollection and KeyDataCollection and added a new ZoneServiceEnum