### PR TITLE
Added export functionality to Process api

### DIFF
--- a/src/Api/ProcessesApi.php
+++ b/src/Api/ProcessesApi.php
@@ -85,4 +85,12 @@ final class ProcessesApi extends AbstractApi
     {
         $this->client->delete(sprintf('v2/processes/%d', $processId));
     }
+
+    public function export(array $parameters = []): array
+    {
+        $query = $parameters;
+        $query['export'] = 'true';
+        $response = $this->client->get('v2/processes', $query);
+        return $response->json()['entities'];
+    }
 }


### PR DESCRIPTION
For a search query we don't get (or need) all the fields of the processes, I've added an export functionality for it, like we also have for https://github.com/sandwave-io/realtimeregister-php/commit/0b221775e2445ac49d87dbf8221efd5b0c6746fa