### PR TITLE
Draft: Fix 2 errors

### DIFF
--- a/src/Api/DomainsApi.php
+++ b/src/Api/DomainsApi.php
@@ -382,7 +382,7 @@ final class DomainsApi extends AbstractApi
         ];
 
         if ($billables instanceof BillableCollection) {
-            $payload['billables'] = $billables;
+            $payload['billables'] = $billables->toArray();
         }
 
         $response = $this->client->post("v2/domains/{$domain}/renew", $payload, is_null($isQuote) ? [] : [
@@ -418,7 +418,7 @@ final class DomainsApi extends AbstractApi
         ];
 
         if ($billables instanceof BillableCollection) {
-            $payload['billables'] = $billables;
+            $payload['billables'] = $billables->toArray();
         }
 
         $response = $this->client->post("v2/domains/{$domain}/restore", $payload, is_null($isQuote) ? [] : [


### PR DESCRIPTION
This pull request fixes two errors I encountered while using this project. 

The first error is a `Warning: Undefined array key "command"` thrown when using the renew() with a quote on the domain API. This is because of the boolean casting, the request generated is buggy because of this. 

The second is an errors thrown because toArray() is not used on billables. 