### PR TITLE
Added DNSKEY as record type

### DIFF
--- a/src/Domain/Enum/DomainZoneRecordTypeEnum.php
+++ b/src/Domain/Enum/DomainZoneRecordTypeEnum.php
@@ -9,6 +9,7 @@ class DomainZoneRecordTypeEnum extends AbstractEnum
     public const TYPE_ALIAS = 'ALIAS';
     public const TYPE_CAA = 'CAA';
     public const TYPE_CNAME = 'CNAME';
+    public const TYPE_DNSKEY = 'DNSKEY';
     public const TYPE_HINFO = 'HINFO';
     public const TYPE_MBOXFW = 'MBOXFW';
     public const TYPE_MX = 'MX';
@@ -26,6 +27,7 @@ class DomainZoneRecordTypeEnum extends AbstractEnum
         self::TYPE_ALIAS,
         self::TYPE_CAA,
         self::TYPE_CNAME,
+        self::TYPE_DNSKEY,
         self::TYPE_HINFO,
         self::TYPE_MBOXFW,
         self::TYPE_MX,


### PR DESCRIPTION
Fixes this error: 

```
SandwaveIo\RealtimeRegister\Exceptions\InvalidArgumentException: Unexpected ENUM value in in class SandwaveIo\RealtimeRegister\Domain\Enum\DomainZoneRecordTypeEnum: DNSKEY. Possible values: (A, AAAA, ALIAS, CAA, CNAME, HINFO, MBOXFW, MX, NAPTR, NS, SOA, SRV, TXT, TLSA, URL)
#91 /vendor/sandwave-io/realtimeregister-php/src/Domain/Enum/AbstractEnum.php(19): SandwaveIo\RealtimeRegister\Domain\Enum\AbstractEnum::assertValueValid
#90 /vendor/sandwave-io/realtimeregister-php/src/Domain/Enum/DomainZoneRecordTypeEnum.php(44): SandwaveIo\RealtimeRegister\Domain\Enum\DomainZoneRecordTypeEnum::validate
#89 /vendor/sandwave-io/realtimeregister-php/src/Domain/DomainZoneRecord.php(35): SandwaveIo\RealtimeRegister\Domain\DomainZoneRecord::fromArray
#88 /vendor/sandwave-io/realtimeregister-php/src/Domain/DomainZoneRecordCollection.php(22): SandwaveIo\RealtimeRegister\Domain\DomainZoneRecordCollection::parseChild
#87 /vendor/sandwave-io/realtimeregister-php/src/Domain/AbstractCollection.php(81): SandwaveIo\RealtimeRegister\Domain\AbstractCollection::{closure:SandwaveIo\RealtimeRegister\Domain\AbstractCollection::fromArray():80}
#86 [internal](0): array_map
#85 /vendor/sandwave-io/realtimeregister-php/src/Domain/AbstractCollection.php(80): SandwaveIo\RealtimeRegister\Domain\AbstractCollection::fromArray
#84 /vendor/sandwave-io/realtimeregister-php/src/Domain/DomainZoneRecordCollection.php(12): SandwaveIo\RealtimeRegister\Domain\DomainZoneRecordCollection::fromArray
#83 /vendor/sandwave-io/realtimeregister-php/src/Domain/DomainZone.php(41): SandwaveIo\RealtimeRegister\Domain\DomainZone::__construct
#82 /vendor/sandwave-io/realtimeregister-php/src/Domain/DomainZone.php(47): SandwaveIo\RealtimeRegister\Domain\DomainZone::fromArray
#81 /vendor/sandwave-io/realtimeregister-php/src/Api/DomainsApi.php(73): SandwaveIo\RealtimeRegister\Api\DomainsApi::zone
```